### PR TITLE
Added forks and job slices display to job views

### DIFF
--- a/awx_tui/dashboards/classic/dashboard.py
+++ b/awx_tui/dashboards/classic/dashboard.py
@@ -214,6 +214,8 @@ class ClassicDashboard(BaseDashboard):
             "Template",
             "Inventory",
             "Execution Environment",
+            "Forks",
+            "Job Slices",
             "Started",
         )
 
@@ -230,7 +232,9 @@ class ClassicDashboard(BaseDashboard):
             "Template",
             "Inventory",
             "Execution Environment",
-            "Time",
+            "Forks",
+            "Job Slices",
+            "Finished",
         )
 
         # Call parent on_mount to trigger initial data load and start auto-refresh timer
@@ -765,6 +769,10 @@ class ClassicDashboard(BaseDashboard):
                 inventory = summary.get("inventory", {}).get("name", "N/A")[:17]
                 exec_env = summary.get("execution_environment", {}).get("name", "N/A")[:21]
 
+            # Get execution parameters
+            forks = str(job.get("forks", "N/A"))
+            job_slice_count = str(job.get("job_slice_count", "N/A"))
+
             # Format started timestamp
             started_str = "N/A"
             started = job.get("started")
@@ -780,7 +788,19 @@ class ClassicDashboard(BaseDashboard):
                 new_cursor_row = idx
 
             table.add_row(
-                jid, type_emoji, status_emoji, name, user, project, playbook, template, inventory, exec_env, started_str
+                jid,
+                type_emoji,
+                status_emoji,
+                name,
+                user,
+                project,
+                playbook,
+                template,
+                inventory,
+                exec_env,
+                forks,
+                job_slice_count,
+                started_str,
             )
 
         # Restore cursor to same job ID if found, otherwise use same row number
@@ -911,6 +931,10 @@ class ClassicDashboard(BaseDashboard):
                 inventory = summary.get("inventory", {}).get("name", "N/A")[:17]
                 exec_env = summary.get("execution_environment", {}).get("name", "N/A")[:21]
 
+            # Get execution parameters
+            forks = str(job.get("forks", "N/A"))
+            job_slice_count = str(job.get("job_slice_count", "N/A"))
+
             # Format finished timestamp
             finished_str = "?"
             finished = job.get("finished")
@@ -936,6 +960,8 @@ class ClassicDashboard(BaseDashboard):
                 template,
                 inventory,
                 exec_env,
+                forks,
+                job_slice_count,
                 finished_str,
             )
 

--- a/awx_tui/modals/job_detail.py
+++ b/awx_tui/modals/job_detail.py
@@ -54,6 +54,10 @@ class JobInfoHeader(Static):
         playbook = job_data.get("playbook", "N/A")
         launch_type = job_data.get("launch_type", "manual")
 
+        # Execution parameters
+        forks = job_data.get("forks", "N/A")
+        job_slice_count = job_data.get("job_slice_count", "N/A")
+
         # Timestamps
         started = job_data.get("started")
         finished = job_data.get("finished")
@@ -111,7 +115,7 @@ class JobInfoHeader(Static):
         # Build compact 4-line header
         info_text = f"""Job #{job_id} {type_emoji} {name[:60]} | {status_text} | Launched via: {launch_emoji} {launch_type.title()}
 👤 {user} | 📦 {project[:30]} | 🎯 {template[:30]} | 📋 {inventory[:25]}
-📄 {playbook[:40]} | ⏱ {started_str} → 🏁 {finished_str} | ⌛ {duration_str}"""
+📄 {playbook[:40]} | 🧵 {forks} | 🍕 {job_slice_count} | ⏱ {started_str} → 🏁 {finished_str} | ⌛ {duration_str}"""
 
         self.update(info_text)
 

--- a/awx_tui/screens/active_jobs.py
+++ b/awx_tui/screens/active_jobs.py
@@ -216,6 +216,8 @@ class ActiveJobsScreen(Screen):
             "Template",
             "Inventory",
             "Execution Environment",
+            "Forks",
+            "Job Slices",
             "Started",
         )
 
@@ -640,6 +642,10 @@ class ActiveJobsScreen(Screen):
                 inventory = summary.get("inventory", {}).get("name", "N/A")[:17]
                 exec_env = summary.get("execution_environment", {}).get("name", "N/A")[:21]
 
+            # Get execution parameters
+            forks = str(job.get("forks", "N/A"))
+            job_slice_count = str(job.get("job_slice_count", "N/A"))
+
             # Format started timestamp
             started_str = "N/A"
             started = job.get("started")
@@ -655,7 +661,19 @@ class ActiveJobsScreen(Screen):
                 new_cursor_row = idx
 
             table.add_row(
-                jid, type_emoji, status_emoji, name, user, project, playbook, template, inventory, exec_env, started_str
+                jid,
+                type_emoji,
+                status_emoji,
+                name,
+                user,
+                project,
+                playbook,
+                template,
+                inventory,
+                exec_env,
+                forks,
+                job_slice_count,
+                started_str,
             )
 
         # Restore cursor to same job ID if found, otherwise use same row number

--- a/awx_tui/screens/historic_jobs.py
+++ b/awx_tui/screens/historic_jobs.py
@@ -215,6 +215,8 @@ class HistoricJobsScreen(Screen):
             "Template",
             "Inventory",
             "Execution Environment",
+            "Forks",
+            "Job Slices",
             "Finished",
         )
 
@@ -714,6 +716,10 @@ class HistoricJobsScreen(Screen):
                 inventory = summary.get("inventory", {}).get("name", "N/A")[:17]
                 exec_env = summary.get("execution_environment", {}).get("name", "N/A")[:21]
 
+            # Get execution parameters
+            forks = str(job.get("forks", "N/A"))
+            job_slice_count = str(job.get("job_slice_count", "N/A"))
+
             # Format finished timestamp
             finished_str = "?"
             finished = job.get("finished")
@@ -739,6 +745,8 @@ class HistoricJobsScreen(Screen):
                 template,
                 inventory,
                 exec_env,
+                forks,
+                job_slice_count,
                 finished_str,
             )
 


### PR DESCRIPTION
- Display forks and job slice count in job detail modal header
- Added Forks and Job Slices columns to Active Jobs screen
- Added Forks and Job Slices columns to Historic Jobs screen
- Added Forks and Job Slices columns to Classic Dashboard (Running and Recent jobs)
- Fixed Classic Dashboard Recent Jobs table: renamed "Time" column to "Finished" for consistency

🤖 AIA: EAI Hin R Claude Code v1.0 (Claude Sonnet 4.5)

Vibe-Coder: Andrew Potozniak <potozniak@redhat.com>

Assisted-By: Claude <noreply@anthropic.com>