### PR TITLE
Normalize URLs to ensure consistent logging

### DIFF
--- a/awx_tui/config.py
+++ b/awx_tui/config.py
@@ -10,8 +10,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from httpx import URL
 import yaml
+from httpx import URL
 
 
 @dataclass

--- a/awx_tui/config.py
+++ b/awx_tui/config.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-import httpx
+from httpx import URL
 import yaml
 
 
@@ -58,11 +58,11 @@ class InstanceConfig:
         if not self.url.startswith(("http://", "https://")):
             raise ValueError(f"URL must start with http:// or https://, got: {self.url}")
 
-        # Normalize the URL using httpx (same normalization httpx applies to response.url).
+        # Normalize the URL using httpx.URL (same normalization httpx applies to response.url).
         # This strips redundant default ports (https:443, http:80) so that error-path
         # log entries (which use self.config.url) are consistent with success-path log
         # entries (which use str(response.url) from httpx).
-        self.url = str(httpx.URL(self.url))
+        self.url = str(URL(self.url))
 
         # Validate auth method (if provided)
         if self.auth_method is not None and self.auth_method not in ("token", "password"):

--- a/awx_tui/config.py
+++ b/awx_tui/config.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import httpx
 import yaml
 
 
@@ -56,6 +57,12 @@ class InstanceConfig:
         # Validate URL
         if not self.url.startswith(("http://", "https://")):
             raise ValueError(f"URL must start with http:// or https://, got: {self.url}")
+
+        # Normalize the URL using httpx (same normalization httpx applies to response.url).
+        # This strips redundant default ports (https:443, http:80) so that error-path
+        # log entries (which use self.config.url) are consistent with success-path log
+        # entries (which use str(response.url) from httpx).
+        self.url = str(httpx.URL(self.url))
 
         # Validate auth method (if provided)
         if self.auth_method is not None and self.auth_method not in ("token", "password"):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,6 +101,42 @@ class TestInstanceConfig:
         with pytest.raises(ValueError, match="Password is required"):
             instance.validate()
 
+    def test_url_normalizes_default_https_port(self):
+        """Test that https with explicit port 443 is normalized"""
+        instance = InstanceConfig(
+            name="test-awx",
+            url="https://awx.example.com:443",
+            auth_method="token",
+            username="admin",
+            token="test-token-123",
+        )
+        instance.validate()
+        assert instance.url == "https://awx.example.com"
+
+    def test_url_normalizes_default_http_port(self):
+        """Test that http with explicit port 80 is normalized"""
+        instance = InstanceConfig(
+            name="test-awx",
+            url="http://awx.example.com:80",
+            auth_method="token",
+            username="admin",
+            token="test-token-123",
+        )
+        instance.validate()
+        assert instance.url == "http://awx.example.com"
+
+    def test_url_preserves_non_default_port(self):
+        """Test that non-default ports are preserved"""
+        instance = InstanceConfig(
+            name="test-awx",
+            url="https://awx.example.com:8443",
+            auth_method="token",
+            username="admin",
+            token="test-token-123",
+        )
+        instance.validate()
+        assert instance.url == "https://awx.example.com:8443"
+
 
 class TestConfigManager:
     """Test ConfigManager functionality"""


### PR DESCRIPTION
## Summary
- Use httpx.URL for URL normalization to strip redundant default ports (https:443, http:80)
- Ensures error-path log entries (using self.config.url) are consistent with success-path log entries (using str(response.url) from httpx)

## Test plan
- [x] Three new tests verify URL normalization behavior
  - test_url_normalizes_default_https_port
  - test_url_normalizes_default_http_port  
  - test_url_preserves_non_default_port

🤖 Generated with [Claude Code](https://claude.com/claude-code)