### PR TITLE
chore: Python 3.12+

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,9 +2,9 @@ name: PR Validation
 
 on:
   push:
-    branches: [ devel ]
+    branches: [devel]
   pull_request:
-    branches: [ devel ]
+    branches: [devel]
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.12"
 
       - name: Install linting tools
         run: |
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -75,10 +75,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.12"
 
       - name: Test clean installation
         run: |

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Screenshots
 
-| | |
-|---|---|
-| ![Multi-Instance Selection](./img/001-awx-tui-multi-instances.png) | ![Classic Dashboard](./img/002-awx-tui-classic-dashboard-v1.png) |
-| ![Sleek Dashboard](./img/003-awx-tui-sleek-dashboard-v1.png) | ![Historic Jobs](./img/004-awx-tui-historic-jobs.png) |
-| ![Active Jobs](./img/005-awx-tui-active-jobs.png) | ![Projects](./img/006-awx-tui-projects.png) |
-| ![Job Templates](./img/007-awx-tui-job-templates.png) | ![Inventories](./img/008-awx-tui-inventories.png) |
-| ![Debug Console](./img/009-awx-tui-debug-console.png) | ![Advanced API Mode](./img/010-awx-tui-advanced-api-mode.png) |
-| ![Create Mode](./img/011-awx-tui-create-mode.png) | ![Create Job Template](./img/012-awx-tui-create-job-template.png) |
-| ![Create Project](./img/013-awx-tui-create-project.png) | ![API Payload Preview](./img/014-awx-tui-create-project-api-payload-preview.png) |
-| ![Job Logs](./img/015-awx-tui-job-logs.png) | ![Job Events](./img/016-awx-tui-job-events.png) |
-| ![Launch Job](./img/017-awx-tui-launch-job.png) | ![Sync Project](./img/018-awx-tui-sync-project.png) |
+|                                                                    |                                                                                  |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| ![Multi-Instance Selection](./img/001-awx-tui-multi-instances.png) | ![Classic Dashboard](./img/002-awx-tui-classic-dashboard-v1.png)                 |
+| ![Sleek Dashboard](./img/003-awx-tui-sleek-dashboard-v1.png)       | ![Historic Jobs](./img/004-awx-tui-historic-jobs.png)                            |
+| ![Active Jobs](./img/005-awx-tui-active-jobs.png)                  | ![Projects](./img/006-awx-tui-projects.png)                                      |
+| ![Job Templates](./img/007-awx-tui-job-templates.png)              | ![Inventories](./img/008-awx-tui-inventories.png)                                |
+| ![Debug Console](./img/009-awx-tui-debug-console.png)              | ![Advanced API Mode](./img/010-awx-tui-advanced-api-mode.png)                    |
+| ![Create Mode](./img/011-awx-tui-create-mode.png)                  | ![Create Job Template](./img/012-awx-tui-create-job-template.png)                |
+| ![Create Project](./img/013-awx-tui-create-project.png)            | ![API Payload Preview](./img/014-awx-tui-create-project-api-payload-preview.png) |
+| ![Job Logs](./img/015-awx-tui-job-logs.png)                        | ![Job Events](./img/016-awx-tui-job-events.png)                                  |
+| ![Launch Job](./img/017-awx-tui-launch-job.png)                    | ![Sync Project](./img/018-awx-tui-sync-project.png)                              |
 
 ## AI-Assisted Project
 
@@ -51,7 +51,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Requirements
 
-- Python 3.8+
+- Python 3.12+
 - AWX 21.x+
 - Linux, macOS, or WSL2 on Windows
 - Terminal size: **188x40** (188 columns × 40 rows) recommended for optimal display
@@ -79,6 +79,7 @@ source ~/.venv-awx-tui/bin/activate
 ```
 
 ### Install Python dependencies
+
 ```bash
 pip install -r requirements.txt
 ```
@@ -93,6 +94,7 @@ python -m awx_tui.main
 > If you do not have any awx instances configured the awx-tui will still launch, but will have no awx instances to target.
 
 ### Configure an AWX instance connection via Environment Variables and launch awx-tui
+
 ```bash
 export AWX_HOST=https://awx.example.com
 export AWX_TOKEN=your-api-token-here
@@ -101,6 +103,7 @@ python -m awx_tui.main
 ```
 
 ### Configure an AWX instance connection via command-line arguments and launch awx-tui
+
 ```bash
 python -m awx_tui.main --host https://awx.example.com --token your-token
 ```
@@ -180,7 +183,7 @@ See [config.yaml.example](./config.yaml.example) for complete configuration guid
 
 ---
 
-## Development 
+## Development
 
 ### Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     {name = "John Mitchell", email = "jmitchel@redhat.com"},
     {name = "John Barker", email = "jobarker@redhat.com"}
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
@@ -22,11 +22,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: System :: Systems Administration",
     "Topic :: Utilities",
 ]
@@ -77,8 +75,8 @@ markers = [
 ]
 
 [tool.ruff]
-# Target Python 3.8+
-target-version = "py38"
+# Target Python 3.12+
+target-version = "py312"
 line-length = 120
 
 # Exclude common directories


### PR DESCRIPTION
## Summary
- Update minimum Python version requirement from 3.8+ to 3.12+
- Update CI/CD workflows to test against Python 3.12, 3.13, and 3.14
- Update project configuration and documentation

## Changes
- `.github/workflows/pr-validation.yml`: Updated Python versions in workflow
- `pyproject.toml`: Updated requires-python and classifiers
- `README.md`: Updated documentation and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)