### PR TITLE
Add Daniel Brennand as Project Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For more information about communication, see the [Ansible communication guide](
 **This project was substantially coded by Large Language Models (LLMs) with human review.**
 
 - **AI Attribution (AIA):** EAI Hin R Claude Code v1.0 (Claude Sonnet 4.5)
-- **Vibe-Coders:** Andrew Potozniak <potozniak@redhat.com>, John Mitchell <jmitchel@redhat.com>, John Barker <jobarker@redhat.com>
+- **Vibe-Coders:** Andrew Potozniak <potozniak@redhat.com>, John Mitchell <jmitchel@redhat.com>, John Barker <jobarker@redhat.com>, Daniel Brennand <dbrenuk@redhat.com>
 - **AWX TUI Logo AI Attribution (AIA):** EAI Hin R Gemini v1.0 (Gemini 3)
 
 > **Note:** This work was mostly AI-generated with human review and may not be subject to traditional copyright protection in some jurisdictions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ license = {text = "MIT"}
 authors = [
     {name = "Andrew Potozniak", email = "potozniak@redhat.com"},
     {name = "John Mitchell", email = "jmitchel@redhat.com"},
-    {name = "John Barker", email = "jobarker@redhat.com"}
+    {name = "John Barker", email = "jobarker@redhat.com"},
+    {name = "Daniel Brennand", email = "dbrenuk@redhat.com"}
 ]
 requires-python = ">=3.12"
 classifiers = [


### PR DESCRIPTION
Adds Daniel Brennand (dbrenuk@redhat.com) as a project maintainer in both `pyproject.toml` and `README.md`.