### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Etc/UTC"
+    versioning-strategy: increase-if-necessary
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "05:00"
       timezone: "Etc/UTC"
     versioning-strategy: increase-if-necessary
@@ -25,8 +24,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "05:00"
       timezone: "Etc/UTC"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for automated dependency updates
- Configures weekly updates (Daily 05:00 UTC) for pip and github-actions ecosystems (will likely change to weekly once confirmed this is working)
- Groups minor/patch pip updates into single PRs; major updates get individual PRs for review
- Supports CRA compliance through timely dependency security patching

## Post-merge steps

Enable in GitHub repository settings (Settings > Code security and analysis):

- [X] 1. Dependency graph
- [X] 2. Dependabot alerts
- [X] 3. Dependabot security updates


## Test plan

- [x] Verify YAML syntax is valid
- [ ] Confirm Dependabot picks up the config after merge (Insights > Dependency graph > Dependabot)
- [ ] Verify PRs are created on the next Monday cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)