### PR TITLE
Fix network connection errors with persistent httpx pooling and add Network Queue view

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ preferences:
   instance_selection_refresh_interval: 5          # Instance health check interval (default: 5)
   show_instance_in_header: true                   # Show active instance in header (default: true)
 
+  # --- Connection Pool Settings ---
+  pool_max_connections: 20                        # Max connections per AWX instance pool (default: 20)
+  pool_max_keepalive_connections: 10              # Max keepalive connections per pool (default: 10)
+  network_queue_refresh_interval: 1               # Network Queue dashboard refresh interval in seconds (default: 1)
+
   # --- Development/Testing ---
   mock_mode: false                                # Enable mock mode (default: false)
 ```
@@ -280,6 +285,7 @@ make clean       # Remove venv and build artifacts
 - `Ctrl+D` - Debug console
 - `Ctrl+T` - Advanced API Mode
 - `Ctrl+O` - The Loaf (notification history)
+- `Ctrl+N` - The Network Queue (connection pool management)
 - `I` or `?` - AWX-TUI Info
 
 ### Dashboard

--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ preferences:
   # --- Connection Pool Settings ---
   pool_max_connections: 20                        # Max connections per AWX instance pool (default: 20)
   pool_max_keepalive_connections: 10              # Max keepalive connections per pool (default: 10)
-  network_queue_refresh_interval: 1               # Network Queue dashboard refresh interval in seconds (default: 1)
 
   # --- Development/Testing ---
   mock_mode: false                                # Enable mock mode (default: false)

--- a/awx_tui/app.py
+++ b/awx_tui/app.py
@@ -200,9 +200,10 @@ class AWXTUIApp(App):
         try:
             self.app_config = self.config_manager.load(cli_args=self.cli_args)
         except Exception as e:
-            # If config fails to load, start with empty config
+            # If config fails to load, start with empty config and notify user
             self.log.error(f"Failed to load config: {e}")
             self.app_config = AppConfig()
+            self.notify(f"Config error: {e}", severity="error", timeout=10)
 
         # Initialize instance manager
         self.instance_manager = InstanceManager(

--- a/awx_tui/app.py
+++ b/awx_tui/app.py
@@ -36,6 +36,7 @@ class AWXTUIApp(App):
         Binding("ctrl+d", "toggle_debug", "Debug", priority=True),
         Binding("ctrl+o", "the_loaf", "Loaf", priority=True),
         Binding("ctrl+t", "advanced_api_mode", "API Mode", priority=True),
+        Binding("ctrl+n", "the_network_queue", "Net Queue", priority=True),
         Binding("c", "create_mode", "Create", priority=True),
         Binding("i", "show_info", "Info"),
         Binding("?", "show_info", "Help"),
@@ -83,6 +84,9 @@ class AWXTUIApp(App):
 
         # Notification log for The Loaf
         self.notification_log = []
+
+        # Connection event log for The Network Queue
+        self.connection_event_log = []
 
         # Create mode state - persists form data until app close
         self.create_mode_state = {
@@ -202,7 +206,10 @@ class AWXTUIApp(App):
 
         # Initialize instance manager
         self.instance_manager = InstanceManager(
-            self.app_config, mock_mode=self.mock_mode, api_call_log=self.api_call_log
+            self.app_config,
+            mock_mode=self.mock_mode,
+            api_call_log=self.api_call_log,
+            connection_event_log=self.connection_event_log,
         )
 
         # Update title with current instance
@@ -314,6 +321,8 @@ class AWXTUIApp(App):
 
     def action_quit(self) -> None:
         """Quit the application"""
+        if self.instance_manager:
+            self.run_worker(self.instance_manager.close_all_clients())
         self.exit()
 
     def action_toggle_debug(self) -> None:
@@ -343,6 +352,17 @@ class AWXTUIApp(App):
 
         # Otherwise, open The Loaf
         self.push_screen(TheLoafScreen())
+
+    def action_the_network_queue(self) -> None:
+        """Open The Network Queue - connection pool debugger - do nothing if already open"""
+        from awx_tui.screens.the_network_queue import TheNetworkQueueScreen
+
+        # If The Network Queue is already the topmost screen, do nothing
+        if isinstance(self.screen, TheNetworkQueueScreen):
+            return
+
+        # Otherwise, open The Network Queue
+        self.push_screen(TheNetworkQueueScreen())
 
     def notify(
         self,

--- a/awx_tui/app.py
+++ b/awx_tui/app.py
@@ -322,9 +322,12 @@ class AWXTUIApp(App):
 
     def action_quit(self) -> None:
         """Quit the application"""
-        if self.instance_manager:
-            self.run_worker(self.instance_manager.close_all_clients())
         self.exit()
+
+    async def on_unmount(self) -> None:
+        """Clean up persistent sessions on app shutdown"""
+        if hasattr(self, "instance_manager") and self.instance_manager:
+            await self.instance_manager.close_all_clients()
 
     def action_toggle_debug(self) -> None:
         """Toggle debug console - do nothing if already open"""

--- a/awx_tui/client.py
+++ b/awx_tui/client.py
@@ -181,7 +181,7 @@ class AWXClient:
                 "max_connections": pool._max_connections,
                 "max_keepalive": pool._max_keepalive_connections,
             }
-        except (AttributeError, Exception):
+        except (Exception):
             return None
 
     def _log_connection_event(self, event: str, details: str) -> None:

--- a/awx_tui/client.py
+++ b/awx_tui/client.py
@@ -166,7 +166,11 @@ class AWXClient:
         self.session = None
 
     def _get_pool_snapshot(self) -> Optional[Dict[str, Any]]:
-        """Capture current connection pool state"""
+        """Capture current connection pool state.
+
+        Uses httpx/httpcore private internals (_transport._pool, _max_connections,
+        _max_keepalive_connections). May break on major httpx/httpcore upgrades.
+        """
         if not self.session or self.session.is_closed:
             return None
         try:

--- a/awx_tui/client.py
+++ b/awx_tui/client.py
@@ -189,7 +189,12 @@ class AWXClient:
             return None
 
     def _log_connection_event(self, event: str, details: str) -> None:
-        """Log a connection pool event to the connection event log"""
+        """Log a connection pool event to the connection event log.
+
+        Note: connection_event_log is a shared mutable list written to by all
+        AWXClient instances. Safe under single-threaded asyncio + CPython GIL,
+        but not thread-safe if the concurrency model changes.
+        """
         if self.connection_event_log is None:
             return
 

--- a/awx_tui/client.py
+++ b/awx_tui/client.py
@@ -181,7 +181,7 @@ class AWXClient:
                 "max_connections": pool._max_connections,
                 "max_keepalive": pool._max_keepalive_connections,
             }
-        except (Exception):
+        except Exception:
             return None
 
     def _log_connection_event(self, event: str, details: str) -> None:

--- a/awx_tui/client.py
+++ b/awx_tui/client.py
@@ -81,6 +81,7 @@ class AWXClient:
         api_call_log: Optional[list] = None,
         timeout: float = 30.0,
         app_config: Optional["AppConfig"] = None,
+        connection_event_log: Optional[list] = None,
     ):
         """
         Initialize AWX client
@@ -90,13 +91,28 @@ class AWXClient:
             api_call_log: Optional list to log API calls for debug console
             timeout: Request timeout in seconds (default: 30)
             app_config: Optional application configuration for preferences
+            connection_event_log: Optional list to log connection pool events
         """
         self.config = instance_config
         self.api_call_log = api_call_log
+        self.connection_event_log = connection_event_log
         self.timeout = timeout
         self.app_config = app_config
         self.session: Optional[httpx.AsyncClient] = None
         self.version_info: Optional[AWXVersion] = None
+
+        # Pool limits: runtime overlay > instance config > global preferences > hardcoded
+        # Runtime overlay is set by modifying these attributes directly
+        global_max = 20
+        global_keepalive = 10
+        if app_config:
+            global_max = app_config.preferences.get("pool_max_connections", 20)
+            global_keepalive = app_config.preferences.get("pool_max_keepalive_connections", 10)
+
+        self.max_connections = getattr(instance_config, "pool_max_connections", None) or global_max
+        self.max_keepalive_connections = (
+            getattr(instance_config, "pool_max_keepalive_connections", None) or global_keepalive
+        )
 
         # Build authentication headers
         self.headers = {
@@ -110,27 +126,87 @@ class AWXClient:
         # Password auth uses HTTP Basic Auth (handled in session creation)
 
     async def __aenter__(self):
-        """Async context manager entry"""
-        # Create httpx.AsyncClient session
-        auth = None
-        if self.config.auth_method == "password":
-            auth = httpx.BasicAuth(username=self.config.username, password=self.config.password or "")
+        """Async context manager entry - creates session only if not already open"""
+        if self.session is None or self.session.is_closed:
+            auth = None
+            if self.config.auth_method == "password":
+                auth = httpx.BasicAuth(username=self.config.username, password=self.config.password or "")
 
-        self.session = httpx.AsyncClient(
-            base_url=self.config.url,
-            headers=self.headers,
-            auth=auth,
-            verify=self.config.verify_ssl,
-            timeout=self.timeout,
-            follow_redirects=True,
-        )
+            self.session = httpx.AsyncClient(
+                base_url=self.config.url,
+                headers=self.headers,
+                auth=auth,
+                verify=self.config.verify_ssl,
+                timeout=self.timeout,
+                follow_redirects=True,
+                limits=httpx.Limits(
+                    max_connections=self.max_connections,
+                    max_keepalive_connections=self.max_keepalive_connections,
+                ),
+            )
+
+            self._log_connection_event(
+                "POOL_CREATED",
+                f"max_connections={self.max_connections}, max_keepalive={self.max_keepalive_connections}",
+            )
 
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Async context manager exit"""
-        if self.session:
+        """Async context manager exit - no-op to keep session persistent"""
+        # Session stays open for reuse across refresh cycles.
+        # Use close() for explicit teardown.
+        pass
+
+    async def close(self):
+        """Explicitly close the persistent httpx session"""
+        if self.session and not self.session.is_closed:
+            self._log_connection_event("POOL_CLOSED", "Session explicitly closed")
             await self.session.aclose()
+        self.session = None
+
+    def _get_pool_snapshot(self) -> Optional[Dict[str, Any]]:
+        """Capture current connection pool state"""
+        if not self.session or self.session.is_closed:
+            return None
+        try:
+            pool = self.session._transport._pool
+            connections = pool.connections
+            idle = sum(1 for c in connections if c.is_idle())
+            active = len(connections) - idle
+            return {
+                "total": len(connections),
+                "idle": idle,
+                "active": active,
+                "max_connections": pool._max_connections,
+                "max_keepalive": pool._max_keepalive_connections,
+            }
+        except (AttributeError, Exception):
+            return None
+
+    def _log_connection_event(self, event: str, details: str) -> None:
+        """Log a connection pool event to the connection event log"""
+        if self.connection_event_log is None:
+            return
+
+        instance_name = self.config.name if (hasattr(self.config, "name") and self.config.name) else "unknown"
+
+        entry = {
+            "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
+            "instance": instance_name,
+            "event": event,
+            "details": details,
+            "pool_snapshot": self._get_pool_snapshot(),
+        }
+
+        self.connection_event_log.append(entry)
+
+        # Ring buffer - cap at 1000 entries
+        max_entries = 1000
+        if self.app_config:
+            max_entries = self.app_config.preferences.get("network_queue_max_entries", 1000)
+        if max_entries > 0 and len(self.connection_event_log) > max_entries:
+            self.connection_event_log[:] = self.connection_event_log[-max_entries:]
 
     def _mask_sensitive_data(self, data: str) -> str:
         """
@@ -409,6 +485,7 @@ class AWXClient:
                 duration_ms=int((datetime.now() - start_time).total_seconds() * 1000),
                 error=f"Connection pool exhausted: {str(e)}",
             )
+            self._log_connection_event("POOL_EXHAUSTED", f"PoolTimeout on {method} {endpoint}: {e}")
             raise AWXClientError(
                 f"Connection pool exhausted for {self.config.url}. "
                 f"Too many concurrent requests. Try again in a moment."
@@ -429,6 +506,7 @@ class AWXClient:
                     duration_ms=duration_ms,
                     error=f"Connection pool full: {error_msg}",
                 )
+                self._log_connection_event("POOL_EXHAUSTED", f"ConnectError on {method} {endpoint}: {error_msg}")
                 raise AWXClientError(
                     f"Too many concurrent connections to {self.config.url}. "
                     f"Connection pool exhausted. Wait for active requests to complete."

--- a/awx_tui/config.py
+++ b/awx_tui/config.py
@@ -437,6 +437,12 @@ class ConfigManager:
             if instance.password:
                 data["instances"][name]["auth"]["password"] = instance.password
 
+            # Add pool settings (only if overridden per-instance)
+            if instance.pool_max_connections is not None:
+                data["instances"][name]["pool_max_connections"] = instance.pool_max_connections
+            if instance.pool_max_keepalive_connections is not None:
+                data["instances"][name]["pool_max_keepalive_connections"] = instance.pool_max_keepalive_connections
+
             # Add cached status
             if instance.last_status:
                 data["instances"][name]["last_status"] = instance.last_status

--- a/awx_tui/config.py
+++ b/awx_tui/config.py
@@ -111,7 +111,6 @@ class AppConfig:
             "mock_mode": False,
             "pool_max_connections": 20,
             "pool_max_keepalive_connections": 10,
-            "network_queue_refresh_interval": 1,
         }
     )
 

--- a/awx_tui/config.py
+++ b/awx_tui/config.py
@@ -29,6 +29,8 @@ class InstanceConfig:
     api_base_path: str = "/api/v2"
     description: str = ""
     dashboard: str = "classic"  # Dashboard layout to use for this instance
+    pool_max_connections: Optional[int] = None  # Per-instance override (default: from preferences)
+    pool_max_keepalive_connections: Optional[int] = None  # Per-instance override (default: from preferences)
     last_status: Optional[str] = None
     last_checked: Optional[str] = None
     last_response_time: Optional[str] = None
@@ -107,6 +109,9 @@ class AppConfig:
             "job_detail_auto_follow": True,
             "show_instance_in_header": True,
             "mock_mode": False,
+            "pool_max_connections": 20,
+            "pool_max_keepalive_connections": 10,
+            "network_queue_refresh_interval": 1,
         }
     )
 
@@ -200,6 +205,8 @@ class ConfigManager:
                     api_base_path=instance_data.get("api_base_path", "/api/v2"),
                     description=instance_data.get("description", ""),
                     dashboard=instance_data.get("dashboard", "classic"),
+                    pool_max_connections=instance_data.get("pool_max_connections"),
+                    pool_max_keepalive_connections=instance_data.get("pool_max_keepalive_connections"),
                     last_status=instance_data.get("last_status"),
                     last_checked=instance_data.get("last_checked"),
                     last_response_time=instance_data.get("last_response_time"),

--- a/awx_tui/instance_manager.py
+++ b/awx_tui/instance_manager.py
@@ -315,7 +315,12 @@ class InstanceManager:
         # Get or create client
         client = self.clients.get(name)
         if isinstance(client, InstanceConfig):
-            client = AWXClient(client, debug_logger=self.debug_logger)
+            client = AWXClient(
+                client,
+                api_call_log=self.api_call_log,
+                app_config=self.config,
+                connection_event_log=self.connection_event_log,
+            )
             self.clients[name] = client
 
         # Test connection

--- a/awx_tui/instance_manager.py
+++ b/awx_tui/instance_manager.py
@@ -6,8 +6,6 @@ Manages multiple AWX instances and their API clients.
 
 from typing import Dict, List, Optional, Union
 
-import httpx
-
 from awx_tui.client import AWXClient
 from awx_tui.config import AppConfig, InstanceConfig
 from awx_tui.mock_data import MOCK_INSTANCES, MockAWXClient
@@ -51,7 +49,6 @@ class InstanceManager:
         self.connection_event_log = connection_event_log
         self.clients: Dict[str, Union[AWXClient, MockAWXClient]] = {}
         self.current_instance: Optional[str] = None
-        self.ping_client: Optional[httpx.AsyncClient] = None
 
         # Initialize instances
         if mock_mode:
@@ -329,34 +326,11 @@ class InstanceManager:
         # MockAWXClient doesn't need async context
         return True
 
-    async def get_ping_client(self) -> httpx.AsyncClient:
-        """Get or create the persistent ping-pool client"""
-        if self.ping_client is None or self.ping_client.is_closed:
-            from awx_tui.ping_checker import _log_ping_connection_event
-
-            self.ping_client = httpx.AsyncClient(
-                verify=False,
-                timeout=10.0,
-                limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
-            )
-            _log_ping_connection_event(
-                self.connection_event_log, "ping-pool", "POOL_CREATED", "max_connections=10, max_keepalive=5"
-            )
-        return self.ping_client
-
     async def close_all_clients(self) -> None:
-        """Close all persistent AWXClient sessions and ping pool (for app shutdown)"""
+        """Close all persistent AWXClient sessions (for app shutdown)"""
         for client in self.clients.values():
             if isinstance(client, AWXClient):
                 await client.close()
-        if self.ping_client and not self.ping_client.is_closed:
-            from awx_tui.ping_checker import _log_ping_connection_event
-
-            _log_ping_connection_event(
-                self.connection_event_log, "ping-pool", "POOL_CLOSED", "Session explicitly closed"
-            )
-            await self.ping_client.aclose()
-            self.ping_client = None
 
     def get_instance_display_name(self, instance_name: Optional[str] = None) -> str:
         """

--- a/awx_tui/instance_manager.py
+++ b/awx_tui/instance_manager.py
@@ -6,6 +6,8 @@ Manages multiple AWX instances and their API clients.
 
 from typing import Dict, List, Optional, Union
 
+import httpx
+
 from awx_tui.client import AWXClient
 from awx_tui.config import AppConfig, InstanceConfig
 from awx_tui.mock_data import MOCK_INSTANCES, MockAWXClient
@@ -27,7 +29,13 @@ class InstanceManager:
     - Supports mock mode with test instances
     """
 
-    def __init__(self, config: AppConfig, mock_mode: bool = False, api_call_log: Optional[list] = None):
+    def __init__(
+        self,
+        config: AppConfig,
+        mock_mode: bool = False,
+        api_call_log: Optional[list] = None,
+        connection_event_log: Optional[list] = None,
+    ):
         """
         Initialize instance manager
 
@@ -35,12 +43,15 @@ class InstanceManager:
             config: Application configuration
             mock_mode: If True, use mock clients instead of real AWX
             api_call_log: Optional list to log API calls for debug console
+            connection_event_log: Optional list to log connection pool events
         """
         self.config = config
         self.mock_mode = mock_mode
         self.api_call_log = api_call_log
+        self.connection_event_log = connection_event_log
         self.clients: Dict[str, Union[AWXClient, MockAWXClient]] = {}
         self.current_instance: Optional[str] = None
+        self.ping_client: Optional[httpx.AsyncClient] = None
 
         # Initialize instances
         if mock_mode:
@@ -186,7 +197,12 @@ class InstanceManager:
         # If client is an InstanceConfig (real mode), create AWXClient
         if isinstance(client, InstanceConfig):
             # Create and cache the AWXClient
-            awx_client = AWXClient(client, api_call_log=self.api_call_log, app_config=self.config)
+            awx_client = AWXClient(
+                client,
+                api_call_log=self.api_call_log,
+                app_config=self.config,
+                connection_event_log=self.connection_event_log,
+            )
             self.clients[instance_name] = awx_client
             return awx_client
 
@@ -312,6 +328,35 @@ class InstanceManager:
 
         # MockAWXClient doesn't need async context
         return True
+
+    async def get_ping_client(self) -> httpx.AsyncClient:
+        """Get or create the persistent ping-pool client"""
+        if self.ping_client is None or self.ping_client.is_closed:
+            from awx_tui.ping_checker import _log_ping_connection_event
+
+            self.ping_client = httpx.AsyncClient(
+                verify=False,
+                timeout=10.0,
+                limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
+            )
+            _log_ping_connection_event(
+                self.connection_event_log, "ping-pool", "POOL_CREATED", "max_connections=10, max_keepalive=5"
+            )
+        return self.ping_client
+
+    async def close_all_clients(self) -> None:
+        """Close all persistent AWXClient sessions and ping pool (for app shutdown)"""
+        for client in self.clients.values():
+            if isinstance(client, AWXClient):
+                await client.close()
+        if self.ping_client and not self.ping_client.is_closed:
+            from awx_tui.ping_checker import _log_ping_connection_event
+
+            _log_ping_connection_event(
+                self.connection_event_log, "ping-pool", "POOL_CLOSED", "Session explicitly closed"
+            )
+            await self.ping_client.aclose()
+            self.ping_client = None
 
     def get_instance_display_name(self, instance_name: Optional[str] = None) -> str:
         """

--- a/awx_tui/ping_checker.py
+++ b/awx_tui/ping_checker.py
@@ -24,31 +24,6 @@ def _prune_api_log(api_call_log: Optional[list], max_entries: int = 1000) -> Non
             api_call_log[:] = api_call_log[-max_entries:]
 
 
-def _log_ping_connection_event(
-    connection_event_log: Optional[list],
-    instance_name: Optional[str],
-    event: str,
-    details: str,
-    max_entries: int = 1000,
-) -> None:
-    """Log a connection event from the ping checker"""
-    if connection_event_log is None:
-        return
-
-    connection_event_log.append(
-        {
-            "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
-            "instance": instance_name or "unknown",
-            "event": event,
-            "details": details,
-            "pool_snapshot": None,
-        }
-    )
-
-    if max_entries > 0 and len(connection_event_log) > max_entries:
-        connection_event_log[:] = connection_event_log[-max_entries:]
-
-
 async def check_instance_ping(
     url: str,
     api_base_path: str = "/api/v2",

--- a/awx_tui/ping_checker.py
+++ b/awx_tui/ping_checker.py
@@ -24,6 +24,31 @@ def _prune_api_log(api_call_log: Optional[list], max_entries: int = 1000) -> Non
             api_call_log[:] = api_call_log[-max_entries:]
 
 
+def _log_ping_connection_event(
+    connection_event_log: Optional[list],
+    instance_name: Optional[str],
+    event: str,
+    details: str,
+    max_entries: int = 1000,
+) -> None:
+    """Log a connection event from the ping checker"""
+    if connection_event_log is None:
+        return
+
+    connection_event_log.append(
+        {
+            "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
+            "instance": instance_name or "unknown",
+            "event": event,
+            "details": details,
+            "pool_snapshot": None,
+        }
+    )
+
+    if max_entries > 0 and len(connection_event_log) > max_entries:
+        connection_event_log[:] = connection_event_log[-max_entries:]
+
+
 async def check_instance_ping(
     url: str,
     api_base_path: str = "/api/v2",
@@ -32,6 +57,8 @@ async def check_instance_ping(
     api_call_log: Optional[list] = None,
     instance_name: Optional[str] = None,
     max_log_entries: int = 1000,
+    connection_event_log: Optional[list] = None,
+    shared_client: Optional[httpx.AsyncClient] = None,
 ) -> Dict[str, Any]:
     """
     Check AWX instance connectivity via ping endpoint
@@ -43,6 +70,8 @@ async def check_instance_ping(
         timeout: Request timeout in seconds
         api_call_log: Optional list to log API calls for debug console
         instance_name: Optional instance name for debug logging
+        connection_event_log: Optional list to log connection pool events
+        shared_client: Optional persistent httpx.AsyncClient to reuse (ping-pool)
 
     Returns:
         Dictionary with:
@@ -57,67 +86,47 @@ async def check_instance_ping(
 
     result = {"status": "unknown", "version": "Unknown", "response_time_ms": 0, "response_time": "N/A", "error": None}
 
+    # Use shared client if provided, otherwise create a throwaway one
+    client = shared_client
+    owns_client = False
+    if client is None:
+        client = httpx.AsyncClient(verify=verify_ssl, timeout=timeout)
+        owns_client = True
+
     try:
-        async with httpx.AsyncClient(verify=verify_ssl, timeout=timeout) as client:
-            response = await client.get(ping_url)
+        response = await client.get(ping_url)
 
-            # Calculate response time
-            elapsed_ms = int((time.time() - start_time) * 1000)
-            result["response_time_ms"] = elapsed_ms
+        # Calculate response time
+        elapsed_ms = int((time.time() - start_time) * 1000)
+        result["response_time_ms"] = elapsed_ms
 
-            # Format response time
-            if elapsed_ms < 1000:
-                result["response_time"] = f"{elapsed_ms}ms"
-            else:
-                result["response_time"] = f"{elapsed_ms / 1000:.1f}s"
+        # Format response time
+        if elapsed_ms < 1000:
+            result["response_time"] = f"{elapsed_ms}ms"
+        else:
+            result["response_time"] = f"{elapsed_ms / 1000:.1f}s"
 
-            # Determine status based on response time
-            if elapsed_ms < 1000:
-                result["status"] = "online"
-            elif elapsed_ms < 5000:
-                result["status"] = "slow"
-            elif elapsed_ms < 10000:
-                result["status"] = "very_slow"
-            else:
-                result["status"] = "offline"
+        # Determine status based on response time
+        if elapsed_ms < 1000:
+            result["status"] = "online"
+        elif elapsed_ms < 5000:
+            result["status"] = "slow"
+        elif elapsed_ms < 10000:
+            result["status"] = "very_slow"
+        else:
+            result["status"] = "offline"
 
-            # Parse response for version - all 2xx codes are success
-            if 200 <= response.status_code < 300:
-                try:
-                    data = response.json()
-                    result["version"] = data.get("version", "Unknown")
+        # Parse response for version - all 2xx codes are success
+        if 200 <= response.status_code < 300:
+            try:
+                data = response.json()
+                result["version"] = data.get("version", "Unknown")
 
-                    # Log successful API call
-                    if api_call_log is not None:
-                        api_call_log.append(
-                            {
-                                "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
-                                "method": "GET",
-                                "instance": url,
-                                "instance_name": instance_name or "unknown",
-                                "endpoint": f"{api_base_path}/ping/",
-                                "url": ping_url,
-                                "status_code": response.status_code,
-                                "duration_ms": elapsed_ms,
-                                "size_bytes": len(response.content),
-                                "request_headers": dict(response.request.headers),
-                                "response_headers": dict(response.headers),
-                                "content_preview": response.text[:500],
-                                "response_content_full": response.text,
-                            }
-                        )
-                        _prune_api_log(api_call_log, max_log_entries)
-                except Exception as e:
-                    result["error"] = f"Failed to parse response: {e}"
-            else:
-                result["status"] = "error"
-                result["error"] = f"HTTP {response.status_code}"
-
-                # Log error API call
+                # Log successful API call
                 if api_call_log is not None:
                     api_call_log.append(
                         {
-                            "timestamp": time.strftime("%H:%M:%S"),
+                            "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
                             "method": "GET",
                             "instance": url,
                             "instance_name": instance_name or "unknown",
@@ -129,10 +138,36 @@ async def check_instance_ping(
                             "request_headers": dict(response.request.headers),
                             "response_headers": dict(response.headers),
                             "content_preview": response.text[:500],
-                            "error": f"HTTP {response.status_code}",
+                            "response_content_full": response.text,
                         }
                     )
                     _prune_api_log(api_call_log, max_log_entries)
+            except Exception as e:
+                result["error"] = f"Failed to parse response: {e}"
+        else:
+            result["status"] = "error"
+            result["error"] = f"HTTP {response.status_code}"
+
+            # Log error API call
+            if api_call_log is not None:
+                api_call_log.append(
+                    {
+                        "timestamp": time.strftime("%H:%M:%S"),
+                        "method": "GET",
+                        "instance": url,
+                        "instance_name": instance_name or "unknown",
+                        "endpoint": f"{api_base_path}/ping/",
+                        "url": ping_url,
+                        "status_code": response.status_code,
+                        "duration_ms": elapsed_ms,
+                        "size_bytes": len(response.content),
+                        "request_headers": dict(response.request.headers),
+                        "response_headers": dict(response.headers),
+                        "content_preview": response.text[:500],
+                        "error": f"HTTP {response.status_code}",
+                    }
+                )
+                _prune_api_log(api_call_log, max_log_entries)
 
     except httpx.TimeoutException:
         elapsed_ms = int((time.time() - start_time) * 1000)
@@ -208,5 +243,10 @@ async def check_instance_ping(
                 }
             )
             _prune_api_log(api_call_log)
+
+    finally:
+        # Only close the client if we created it (throwaway)
+        if owns_client:
+            await client.aclose()
 
     return result

--- a/awx_tui/ping_checker.py
+++ b/awx_tui/ping_checker.py
@@ -58,7 +58,7 @@ async def check_instance_ping(
     instance_name: Optional[str] = None,
     max_log_entries: int = 1000,
     connection_event_log: Optional[list] = None,
-    shared_client: Optional[httpx.AsyncClient] = None,
+    instance_client: Optional[httpx.AsyncClient] = None,
 ) -> Dict[str, Any]:
     """
     Check AWX instance connectivity via ping endpoint
@@ -71,7 +71,7 @@ async def check_instance_ping(
         api_call_log: Optional list to log API calls for debug console
         instance_name: Optional instance name for debug logging
         connection_event_log: Optional list to log connection pool events
-        shared_client: Optional persistent httpx.AsyncClient to reuse (ping-pool)
+        instance_client: Optional instance's httpx.AsyncClient session to reuse
 
     Returns:
         Dictionary with:
@@ -86,8 +86,8 @@ async def check_instance_ping(
 
     result = {"status": "unknown", "version": "Unknown", "response_time_ms": 0, "response_time": "N/A", "error": None}
 
-    # Use shared client if provided, otherwise create a throwaway one
-    client = shared_client
+    # Use instance client if provided, otherwise create a throwaway one
+    client = instance_client
     owns_client = False
     if client is None:
         client = httpx.AsyncClient(verify=verify_ssl, timeout=timeout)

--- a/awx_tui/ping_checker.py
+++ b/awx_tui/ping_checker.py
@@ -128,7 +128,7 @@ async def check_instance_ping(
             if api_call_log is not None:
                 api_call_log.append(
                     {
-                        "timestamp": time.strftime("%H:%M:%S"),
+                        "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
                         "method": "GET",
                         "instance": url,
                         "instance_name": instance_name or "unknown",
@@ -156,7 +156,7 @@ async def check_instance_ping(
         if api_call_log is not None:
             api_call_log.append(
                 {
-                    "timestamp": time.strftime("%H:%M:%S"),
+                    "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
                     "method": "GET",
                     "instance": url,
                     "instance_name": instance_name or "unknown",
@@ -181,7 +181,7 @@ async def check_instance_ping(
         if api_call_log is not None:
             api_call_log.append(
                 {
-                    "timestamp": time.strftime("%H:%M:%S"),
+                    "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
                     "method": "GET",
                     "instance": url,
                     "instance_name": instance_name or "unknown",
@@ -206,7 +206,7 @@ async def check_instance_ping(
         if api_call_log is not None:
             api_call_log.append(
                 {
-                    "timestamp": time.strftime("%H:%M:%S"),
+                    "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
                     "method": "GET",
                     "instance": url,
                     "instance_name": instance_name or "unknown",

--- a/awx_tui/ping_checker.py
+++ b/awx_tui/ping_checker.py
@@ -57,7 +57,6 @@ async def check_instance_ping(
     api_call_log: Optional[list] = None,
     instance_name: Optional[str] = None,
     max_log_entries: int = 1000,
-    connection_event_log: Optional[list] = None,
     instance_client: Optional[httpx.AsyncClient] = None,
 ) -> Dict[str, Any]:
     """
@@ -70,7 +69,6 @@ async def check_instance_ping(
         timeout: Request timeout in seconds
         api_call_log: Optional list to log API calls for debug console
         instance_name: Optional instance name for debug logging
-        connection_event_log: Optional list to log connection pool events
         instance_client: Optional instance's httpx.AsyncClient session to reuse
 
     Returns:
@@ -93,8 +91,11 @@ async def check_instance_ping(
         client = httpx.AsyncClient(verify=verify_ssl, timeout=timeout)
         owns_client = True
 
+    # Instance client has base_url set, so use relative path; throwaway client needs full URL
+    request_url = f"{api_base_path}/ping/" if instance_client else ping_url
+
     try:
-        response = await client.get(ping_url)
+        response = await client.get(request_url)
 
         # Calculate response time
         elapsed_ms = int((time.time() - start_time) * 1000)

--- a/awx_tui/screens/instance_selection.py
+++ b/awx_tui/screens/instance_selection.py
@@ -356,8 +356,8 @@ class InstanceSelectionScreen(Screen):
                 if hasattr(self.app, "instance_manager") and self.app.instance_manager:
                     client = self.app.instance_manager.get_client(name)
                     if isinstance(client, AWXClient):
-                        async with client:
-                            instance_session = client.session
+                        await client.__aenter__()  # Ensure session is open
+                        instance_session = client.session
 
                 ping_result = await check_instance_ping(
                     url=config.url,

--- a/awx_tui/screens/instance_selection.py
+++ b/awx_tui/screens/instance_selection.py
@@ -351,6 +351,11 @@ class InstanceSelectionScreen(Screen):
                 # Real instance - ping it
                 from awx_tui.ping_checker import check_instance_ping
 
+                # Get shared ping client from instance manager
+                shared_ping = None
+                if hasattr(self.app, "instance_manager") and self.app.instance_manager:
+                    shared_ping = await self.app.instance_manager.get_ping_client()
+
                 ping_result = await check_instance_ping(
                     url=config.url,
                     api_base_path=config.api_base_path,
@@ -359,6 +364,8 @@ class InstanceSelectionScreen(Screen):
                     api_call_log=self.app.api_call_log if hasattr(self.app, "api_call_log") else None,
                     instance_name=name,
                     max_log_entries=self.app.app_config.preferences.get("debug_console_max_entries", 1000),
+                    connection_event_log=getattr(self.app, "connection_event_log", None),
+                    shared_client=shared_ping,
                 )
 
                 status = ping_result["status"]

--- a/awx_tui/screens/instance_selection.py
+++ b/awx_tui/screens/instance_selection.py
@@ -367,7 +367,6 @@ class InstanceSelectionScreen(Screen):
                     api_call_log=self.app.api_call_log if hasattr(self.app, "api_call_log") else None,
                     instance_name=name,
                     max_log_entries=self.app.app_config.preferences.get("debug_console_max_entries", 1000),
-                    connection_event_log=getattr(self.app, "connection_event_log", None),
                     instance_client=instance_session,
                 )
 

--- a/awx_tui/screens/instance_selection.py
+++ b/awx_tui/screens/instance_selection.py
@@ -348,13 +348,16 @@ class InstanceSelectionScreen(Screen):
                 config.last_checked = time.strftime("%Y-%m-%d %H:%M:%S")
                 config.last_response_time = response_time
             else:
-                # Real instance - ping it
+                # Real instance - ping using the instance's own AWXClient session
+                from awx_tui.client import AWXClient
                 from awx_tui.ping_checker import check_instance_ping
 
-                # Get shared ping client from instance manager
-                shared_ping = None
+                instance_session = None
                 if hasattr(self.app, "instance_manager") and self.app.instance_manager:
-                    shared_ping = await self.app.instance_manager.get_ping_client()
+                    client = self.app.instance_manager.get_client(name)
+                    if isinstance(client, AWXClient):
+                        async with client:
+                            instance_session = client.session
 
                 ping_result = await check_instance_ping(
                     url=config.url,
@@ -365,7 +368,7 @@ class InstanceSelectionScreen(Screen):
                     instance_name=name,
                     max_log_entries=self.app.app_config.preferences.get("debug_console_max_entries", 1000),
                     connection_event_log=getattr(self.app, "connection_event_log", None),
-                    shared_client=shared_ping,
+                    instance_client=instance_session,
                 )
 
                 status = ping_result["status"]

--- a/awx_tui/screens/the_loaf.py
+++ b/awx_tui/screens/the_loaf.py
@@ -75,7 +75,7 @@ class TheLoafScreen(Screen):
         content-align: center middle;
         text-style: bold;
         color: $accent;
-        padding: 1;
+        padding: 0;
     }
 
     #loaf_content {

--- a/awx_tui/screens/the_network_queue.py
+++ b/awx_tui/screens/the_network_queue.py
@@ -1,0 +1,435 @@
+"""
+AWX TUI - The Network Queue Screen
+
+Connection pool management dashboard with live pool status,
+per-connection details, and historical event log.
+"""
+
+import re
+
+import httpx
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Header, Static
+
+
+class TheNetworkQueueScreen(Screen):
+    """
+    The Network Queue - Connection Pool Management Dashboard
+
+    Three sections:
+    1. Pool Overview - all pools with high-level stats
+    2. Connections - individual connections in the selected pool
+    3. Event Log - historical connection events with detail panel
+    """
+
+    CSS = """
+    #nq_title_bar {
+        width: 100%;
+        height: auto;
+        dock: top;
+        background: $boost;
+        border-bottom: solid $primary;
+        padding: 0 1;
+    }
+
+    #nq_title {
+        width: 100%;
+        content-align: center middle;
+        text-style: bold;
+        color: $accent;
+        padding: 0;
+    }
+
+    #nq_main {
+        width: 100%;
+        height: 1fr;
+    }
+
+    #pool_table {
+        height: auto;
+        max-height: 12;
+        border: solid $primary;
+        margin: 0 1;
+    }
+
+    #conn_label {
+        padding: 0 1;
+        color: $text-muted;
+        height: auto;
+    }
+
+    #conn_table {
+        height: 12;
+        border: solid $secondary;
+        margin: 0 1;
+    }
+
+    #event_label {
+        padding: 0 1;
+        color: $text-muted;
+        height: auto;
+    }
+
+    #event_list {
+        height: 7;
+        border: solid $primary;
+        margin: 0 1 1 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("backspace", "back", "Back", show=False),
+        Binding("ctrl+q", "quit", "Quit", show=False),
+        Binding("r", "refresh", "Refresh", show=True),
+        Binding("ctrl+k", "close_pool", "Close Pool", show=True),
+        Binding("ctrl+x", "purge", "Purge Log", show=True),
+        Binding("ctrl+n", "no_action", "", show=False),
+    ]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.event_data = []
+        self.pool_data = []  # List of (instance_name, client) tuples for pool table
+        self.selected_pool_name = None
+        self._refresh_timer = None
+
+    def compose(self) -> ComposeResult:
+        """Create the network queue dashboard layout"""
+        yield Header()
+
+        # Title bar
+        with Container(id="nq_title_bar"):
+            yield Static("The Network Queue", id="nq_title")
+
+        # Main content - vertically stacked sections
+        with Vertical(id="nq_main"):
+            # Section 1: Pool overview table
+            pool_table = DataTable(id="pool_table", cursor_type="row")
+            pool_table.add_columns("Instance", "Status", "Conns", "Active", "Idle", "Max", "Keepalive")
+            yield pool_table
+
+            # Section 2: Connection detail table
+            yield Static("Connections: Select a pool above", id="conn_label")
+            conn_table = DataTable(id="conn_table", cursor_type="row")
+            conn_table.add_columns("Origin", "HTTP Version", "State", "Request Count")
+            yield conn_table
+
+            # Section 3: Pool event log
+            yield Static("Pool Event Log", id="event_label")
+            event_table = DataTable(id="event_list", cursor_type="row")
+            event_table.add_columns("Time", "Instance", "Event", "Details")
+            yield event_table
+
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Initialize the dashboard"""
+        self.refresh_all()
+
+        # Start auto-refresh timer
+        refresh_interval = 1
+        if hasattr(self.app, "app_config") and self.app.app_config:
+            refresh_interval = self.app.app_config.preferences.get("network_queue_refresh_interval", 1)
+        if refresh_interval > 0:
+            self._refresh_timer = self.set_interval(refresh_interval, self._auto_refresh)
+
+    def _auto_refresh(self) -> None:
+        """Auto-refresh pool and connection tables (silent)"""
+        self.load_pools()
+        self.load_connections()
+        self.load_events()
+
+    def refresh_all(self) -> None:
+        """Load all three sections"""
+        self.load_pools()
+        self.load_connections()
+        self.load_events()
+
+        # Auto-select first pool if available
+        pool_table = self.query_one("#pool_table", DataTable)
+        if self.pool_data:
+            pool_table.cursor_coordinate = (0, 0)
+            self.selected_pool_name = self.pool_data[0][0]
+            self.load_connections()
+
+        # Auto-select last event row
+        event_table = self.query_one("#event_list", DataTable)
+        if self.event_data:
+            last_row = len(self.event_data) - 1
+            event_table.cursor_coordinate = (last_row, 0)
+
+    def load_pools(self) -> None:
+        """Load pool overview table"""
+        pool_table = self.query_one("#pool_table", DataTable)
+
+        # Remember selection
+        prev_selected = self.selected_pool_name
+
+        pool_table.clear()
+        self.pool_data = []
+
+        instance_manager = getattr(self.app, "instance_manager", None)
+        if not instance_manager:
+            return
+
+        from awx_tui.client import AWXClient
+        from awx_tui.config import InstanceConfig
+        from awx_tui.mock_data import MockAWXClient
+
+        for name in instance_manager.get_instance_names():
+            client = instance_manager.clients.get(name)
+
+            if isinstance(client, AWXClient) and client.session and not client.session.is_closed:
+                try:
+                    pool = client.session._transport._pool
+                    connections = pool.connections
+                    idle = sum(1 for c in connections if c.is_idle())
+                    active = len(connections) - idle
+
+                    pool_table.add_row(
+                        name,
+                        "[green]●[/green] Active",
+                        str(len(connections)),
+                        str(active),
+                        str(idle),
+                        str(pool._max_connections),
+                        str(pool._max_keepalive_connections),
+                    )
+                    self.pool_data.append((name, client))
+                except (AttributeError, Exception):
+                    pool_table.add_row(name, "[yellow]●[/yellow] Unknown", "-", "-", "-", "-", "-")
+                    self.pool_data.append((name, client))
+            elif isinstance(client, AWXClient):
+                pool_table.add_row(
+                    name,
+                    "[dim]○[/dim] No session",
+                    "0",
+                    "0",
+                    "0",
+                    str(client.max_connections),
+                    str(client.max_keepalive_connections),
+                )
+                self.pool_data.append((name, client))
+            elif isinstance(client, InstanceConfig):
+                pool_table.add_row(name, "[dim]○[/dim] Not connected", "-", "-", "-", "-", "-")
+                self.pool_data.append((name, None))
+            elif isinstance(client, MockAWXClient):
+                pool_table.add_row(name, "[dim]○[/dim] Mock", "-", "-", "-", "-", "-")
+                self.pool_data.append((name, None))
+
+        # Add ping-pool if it exists
+        ping_client = getattr(instance_manager, "ping_client", None)
+        if ping_client and not ping_client.is_closed:
+            try:
+                pool = ping_client._transport._pool
+                connections = pool.connections
+                idle = sum(1 for c in connections if c.is_idle())
+                active = len(connections) - idle
+
+                pool_table.add_row(
+                    "ping-pool",
+                    "[cyan]●[/cyan] Active",
+                    str(len(connections)),
+                    str(active),
+                    str(idle),
+                    str(pool._max_connections),
+                    str(pool._max_keepalive_connections),
+                )
+                self.pool_data.append(("ping-pool", ping_client))
+            except (AttributeError, Exception):
+                pool_table.add_row("ping-pool", "[yellow]●[/yellow] Unknown", "-", "-", "-", "-", "-")
+                self.pool_data.append(("ping-pool", ping_client))
+        elif ping_client is None:
+            pool_table.add_row("ping-pool", "[dim]○[/dim] Not started", "-", "-", "-", "-", "-")
+            self.pool_data.append(("ping-pool", None))
+
+        # Restore selection
+        if prev_selected:
+            for i, (pname, _) in enumerate(self.pool_data):
+                if pname == prev_selected:
+                    pool_table.cursor_coordinate = (i, 0)
+                    break
+
+    def load_connections(self) -> None:
+        """Load connections for the selected pool"""
+        conn_table = self.query_one("#conn_table", DataTable)
+        conn_label = self.query_one("#conn_label", Static)
+
+        conn_table.clear()
+
+        if not self.selected_pool_name:
+            conn_label.update("Connections: Select a pool above")
+            return
+
+        # Find the client for the selected pool
+        client = None
+        for pname, pclient in self.pool_data:
+            if pname == self.selected_pool_name:
+                client = pclient
+                break
+
+        from awx_tui.client import AWXClient
+
+        # Resolve the httpx session - either from AWXClient or raw httpx.AsyncClient (ping-pool)
+        session = None
+        if isinstance(client, AWXClient) and client.session and not client.session.is_closed:
+            session = client.session
+        elif isinstance(client, httpx.AsyncClient) and not client.is_closed:
+            session = client
+
+        if session is None:
+            conn_label.update(f"Connections: {self.selected_pool_name} (no active session)")
+            return
+
+        try:
+            pool = session._transport._pool
+            connections = pool.connections
+            conn_label.update(f"Connections: {self.selected_pool_name} ({len(connections)} total)")
+
+            for conn in connections:
+                info_str = str(conn.info())
+
+                # Parse conn.info() string: "'host:port', HTTP/1.1, IDLE, Request Count: 5"
+                origin = "unknown"
+                http_ver = "unknown"
+                req_count = "0"
+
+                # Extract origin
+                origin_match = re.search(r"'([^']+)'", info_str)
+                if origin_match:
+                    origin = origin_match.group(1)
+
+                # Extract HTTP version
+                http_match = re.search(r"(HTTP/[\d.]+)", info_str)
+                if http_match:
+                    http_ver = http_match.group(1)
+
+                # Extract request count
+                count_match = re.search(r"Request Count:\s*(\d+)", info_str)
+                if count_match:
+                    req_count = count_match.group(1)
+
+                # State
+                if conn.is_closed():
+                    state = "[red]CLOSED[/red]"
+                elif conn.is_idle():
+                    state = "[green]IDLE[/green]"
+                else:
+                    state = "[yellow]ACTIVE[/yellow]"
+
+                conn_table.add_row(origin, http_ver, state, req_count)
+
+        except (AttributeError, Exception):
+            conn_label.update(f"Connections: {self.selected_pool_name} (introspection unavailable)")
+
+    def load_events(self) -> None:
+        """Load connection events from app's connection event log"""
+        event_table = self.query_one("#event_list", DataTable)
+
+        # Remember selection
+        prev_row = None
+        if hasattr(event_table, "cursor_coordinate") and event_table.cursor_coordinate:
+            prev_row = event_table.cursor_coordinate[0]
+
+        event_table.clear()
+        self.event_data = []
+
+        events = getattr(self.app, "connection_event_log", [])
+
+        for event in reversed(events):
+            timestamp = event.get("timestamp", "Unknown")
+            instance = event.get("instance", "Unknown")
+            event_type = event.get("event", "Unknown")
+            details = str(event.get("details", ""))[:60]
+
+            event_emoji = {
+                "POOL_CREATED": "[green]✓[/green]",
+                "POOL_CLOSED": "[yellow]✗[/yellow]",
+                "POOL_EXHAUSTED": "[red]✗[/red]",
+                "PING_CONN_OPENED": "[cyan]↔[/cyan]",
+            }.get(event_type, "ℹ ")
+
+            event_table.add_row(timestamp, instance, f"{event_emoji} {event_type}", details)
+            self.event_data.append(event)
+
+        # Restore selection
+        if prev_row is not None and prev_row < len(self.event_data):
+            event_table.cursor_coordinate = (prev_row, 0)
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Handle row highlight in any table"""
+        if event.data_table.id == "pool_table":
+            row_index = event.cursor_row
+            if 0 <= row_index < len(self.pool_data):
+                self.selected_pool_name = self.pool_data[row_index][0]
+                self.load_connections()
+
+    def action_back(self) -> None:
+        """Close the network queue screen"""
+        if self._refresh_timer:
+            self._refresh_timer.stop()
+        self.app.pop_screen()
+
+    def action_refresh(self) -> None:
+        """Manual refresh all sections"""
+        self.refresh_all()
+        self.notify("Network Queue refreshed", timeout=1)
+
+    def action_close_pool(self) -> None:
+        """Close the selected pool's session"""
+        if not self.selected_pool_name:
+            self.notify("No pool selected", severity="warning", timeout=2)
+            return
+
+        for pname, pclient in self.pool_data:
+            if pname == self.selected_pool_name:
+                from awx_tui.client import AWXClient
+
+                if isinstance(pclient, AWXClient) and pclient.session and not pclient.session.is_closed:
+                    self.run_worker(self._do_close_pool(pclient, pname))
+                elif pname == "ping-pool" and isinstance(pclient, httpx.AsyncClient) and not pclient.is_closed:
+                    self.run_worker(self._do_close_ping_pool(pclient))
+                else:
+                    self.notify(f"{pname}: No active session to close", severity="warning", timeout=2)
+                return
+
+    async def _do_close_pool(self, client, name: str) -> None:
+        """Actually close an AWXClient pool"""
+        await client.close()
+        self.notify(f"Pool closed: {name}", timeout=2)
+        self.refresh_all()
+
+    async def _do_close_ping_pool(self, client) -> None:
+        """Close the ping-pool"""
+        instance_manager = getattr(self.app, "instance_manager", None)
+        if instance_manager:
+            from awx_tui.ping_checker import _log_ping_connection_event
+
+            _log_ping_connection_event(
+                getattr(self.app, "connection_event_log", None), "ping-pool", "POOL_CLOSED", "Closed from Network Queue"
+            )
+            await client.aclose()
+            instance_manager.ping_client = None
+        self.notify("Pool closed: ping-pool", timeout=2)
+        self.refresh_all()
+
+    def action_purge(self) -> None:
+        """Purge all connection event data"""
+        if hasattr(self.app, "connection_event_log"):
+            self.app.connection_event_log.clear()
+            self.notify("Connection event log purged", severity="warning")
+            self.load_events()
+
+    def action_no_action(self) -> None:
+        """Do nothing - used to override Ctrl+N"""
+        pass
+
+    def action_quit(self) -> None:
+        """Quit the application"""
+        if self._refresh_timer:
+            self._refresh_timer.stop()
+        self.app.exit()

--- a/awx_tui/screens/the_network_queue.py
+++ b/awx_tui/screens/the_network_queue.py
@@ -6,12 +6,71 @@ per-connection details, and historical event log.
 """
 
 import re
+from typing import Any, List, Tuple
 
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Vertical
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Header, Static
+
+
+def _snapshot_pool_connections(pool) -> Tuple[List[Tuple[str, bool, bool]], int, int]:
+    """Capture a point-in-time snapshot of all connections in a pool.
+
+    Returns:
+        Tuple of (conn_snapshot, idle_count, active_count) where conn_snapshot
+        is a list of (info_str, is_idle, is_closed) tuples.
+    """
+    conn_snapshot = []
+    idle = 0
+    for conn in pool.connections:
+        info_str = str(conn.info())
+        is_idle = conn.is_idle()
+        is_closed = conn.is_closed()
+        if is_idle:
+            idle += 1
+        conn_snapshot.append((info_str, is_idle, is_closed))
+
+    active = len(conn_snapshot) - idle
+    return conn_snapshot, idle, active
+
+
+def _parse_connection_info(info_str: str) -> Tuple[str, str, str]:
+    """Parse an httpcore connection info string into components.
+
+    Args:
+        info_str: String like "'host:port', HTTP/1.1, IDLE, Request Count: 5"
+
+    Returns:
+        Tuple of (origin, http_version, request_count)
+    """
+    origin = "unknown"
+    http_ver = "unknown"
+    req_count = "0"
+
+    origin_match = re.search(r"'([^']+)'", info_str)
+    if origin_match:
+        origin = origin_match.group(1)
+
+    http_match = re.search(r"(HTTP/[\d.]+)", info_str)
+    if http_match:
+        http_ver = http_match.group(1)
+
+    count_match = re.search(r"Request Count:\s*(\d+)", info_str)
+    if count_match:
+        req_count = count_match.group(1)
+
+    return origin, http_ver, req_count
+
+
+def _connection_state_label(is_idle: bool, is_closed: bool) -> str:
+    """Return a colored state label for a connection."""
+    if is_closed:
+        return "[red]CLOSED[/red]"
+    if is_idle:
+        return "[green]IDLE[/green]"
+    return "[yellow]ACTIVE[/yellow]"
 
 
 class TheNetworkQueueScreen(Screen):
@@ -21,7 +80,7 @@ class TheNetworkQueueScreen(Screen):
     Three sections:
     1. Pool Overview - all pools with high-level stats
     2. Connections - individual connections in the selected pool
-    3. Event Log - historical connection events with detail panel
+    3. Event Log - historical connection events
     """
 
     CSS = """
@@ -128,7 +187,7 @@ class TheNetworkQueueScreen(Screen):
         """Initialize the dashboard"""
         self.refresh_all()
 
-def refresh_all(self) -> None:
+    def refresh_all(self) -> None:
         """Load all three sections"""
         self.load_pools()
         self.load_connections()
@@ -147,11 +206,60 @@ def refresh_all(self) -> None:
             last_row = len(self.event_data) - 1
             event_table.cursor_coordinate = (last_row, 0)
 
+    def _get_pool_row(self, name, client) -> Tuple[tuple, Any, list]:
+        """Build a pool table row and snapshot for a single client.
+
+        Returns:
+            Tuple of (row_values, client_ref, conn_snapshot)
+        """
+        from awx_tui.client import AWXClient
+        from awx_tui.config import InstanceConfig
+        from awx_tui.mock_data import MockAWXClient
+
+        if isinstance(client, AWXClient) and client.session and not client.session.is_closed:
+            try:
+                pool = client.session._transport._pool
+                conn_snapshot, idle, active = _snapshot_pool_connections(pool)
+                row = (
+                    name,
+                    "[green]●[/green] Active",
+                    str(len(conn_snapshot)),
+                    str(active),
+                    str(idle),
+                    str(pool._max_connections),
+                    str(pool._max_keepalive_connections),
+                )
+                return row, client, conn_snapshot
+            except Exception:
+                row = (name, "[yellow]●[/yellow] Unknown", "-", "-", "-", "-", "-")
+                return row, client, []
+
+        if isinstance(client, AWXClient):
+            row = (
+                name,
+                "[dim]○[/dim] No session",
+                "0",
+                "0",
+                "0",
+                str(client.max_connections),
+                str(client.max_keepalive_connections),
+            )
+            return row, client, []
+
+        if isinstance(client, InstanceConfig):
+            row = (name, "[dim]○[/dim] Not connected", "-", "-", "-", "-", "-")
+            return row, None, []
+
+        if isinstance(client, MockAWXClient):
+            row = (name, "[dim]○[/dim] Mock", "-", "-", "-", "-", "-")
+            return row, None, []
+
+        row = (name, "[dim]○[/dim] Unknown", "-", "-", "-", "-", "-")
+        return row, None, []
+
     def load_pools(self) -> None:
         """Load pool overview table"""
         pool_table = self.query_one("#pool_table", DataTable)
-
-        # Remember selection
         prev_selected = self.selected_pool_name
 
         pool_table.clear()
@@ -161,61 +269,11 @@ def refresh_all(self) -> None:
         if not instance_manager:
             return
 
-        from awx_tui.client import AWXClient
-        from awx_tui.config import InstanceConfig
-        from awx_tui.mock_data import MockAWXClient
-
         for name in instance_manager.get_instance_names():
             client = instance_manager.clients.get(name)
-
-            if isinstance(client, AWXClient) and client.session and not client.session.is_closed:
-                try:
-                    pool = client.session._transport._pool
-                    connections = pool.connections
-
-                    # Snapshot connection details now so load_connections sees the same state
-                    conn_snapshot = []
-                    idle = 0
-                    for conn in connections:
-                        info_str = str(conn.info())
-                        is_idle = conn.is_idle()
-                        is_closed = conn.is_closed()
-                        if is_idle:
-                            idle += 1
-                        conn_snapshot.append((info_str, is_idle, is_closed))
-
-                    active = len(connections) - idle
-
-                    pool_table.add_row(
-                        name,
-                        "[green]●[/green] Active",
-                        str(len(connections)),
-                        str(active),
-                        str(idle),
-                        str(pool._max_connections),
-                        str(pool._max_keepalive_connections),
-                    )
-                    self.pool_data.append((name, client, conn_snapshot))
-                except (Exception):
-                    pool_table.add_row(name, "[yellow]●[/yellow] Unknown", "-", "-", "-", "-", "-")
-                    self.pool_data.append((name, client, []))
-            elif isinstance(client, AWXClient):
-                pool_table.add_row(
-                    name,
-                    "[dim]○[/dim] No session",
-                    "0",
-                    "0",
-                    "0",
-                    str(client.max_connections),
-                    str(client.max_keepalive_connections),
-                )
-                self.pool_data.append((name, client, []))
-            elif isinstance(client, InstanceConfig):
-                pool_table.add_row(name, "[dim]○[/dim] Not connected", "-", "-", "-", "-", "-")
-                self.pool_data.append((name, None, []))
-            elif isinstance(client, MockAWXClient):
-                pool_table.add_row(name, "[dim]○[/dim] Mock", "-", "-", "-", "-", "-")
-                self.pool_data.append((name, None, []))
+            row, client_ref, conn_snapshot = self._get_pool_row(name, client)
+            pool_table.add_row(*row)
+            self.pool_data.append((name, client_ref, conn_snapshot))
 
         # Restore selection
         if prev_selected:
@@ -249,30 +307,8 @@ def refresh_all(self) -> None:
         conn_label.update(f"Connections: {self.selected_pool_name} ({len(conn_snapshot)} total)")
 
         for info_str, is_idle, is_closed in conn_snapshot:
-            # Parse conn.info() string: "'host:port', HTTP/1.1, IDLE, Request Count: 5"
-            origin = "unknown"
-            http_ver = "unknown"
-            req_count = "0"
-
-            origin_match = re.search(r"'([^']+)'", info_str)
-            if origin_match:
-                origin = origin_match.group(1)
-
-            http_match = re.search(r"(HTTP/[\d.]+)", info_str)
-            if http_match:
-                http_ver = http_match.group(1)
-
-            count_match = re.search(r"Request Count:\s*(\d+)", info_str)
-            if count_match:
-                req_count = count_match.group(1)
-
-            if is_closed:
-                state = "[red]CLOSED[/red]"
-            elif is_idle:
-                state = "[green]IDLE[/green]"
-            else:
-                state = "[yellow]ACTIVE[/yellow]"
-
+            origin, http_ver, req_count = _parse_connection_info(info_str)
+            state = _connection_state_label(is_idle, is_closed)
             conn_table.add_row(origin, http_ver, state, req_count)
 
     def load_events(self) -> None:

--- a/awx_tui/screens/the_network_queue.py
+++ b/awx_tui/screens/the_network_queue.py
@@ -199,7 +199,7 @@ class TheNetworkQueueScreen(Screen):
                         str(pool._max_keepalive_connections),
                     )
                     self.pool_data.append((name, client))
-                except (AttributeError, Exception):
+                except (Exception):
                     pool_table.add_row(name, "[yellow]●[/yellow] Unknown", "-", "-", "-", "-", "-")
                     self.pool_data.append((name, client))
             elif isinstance(client, AWXClient):
@@ -289,7 +289,7 @@ class TheNetworkQueueScreen(Screen):
 
                 conn_table.add_row(origin, http_ver, state, req_count)
 
-        except (AttributeError, Exception):
+        except (Exception):
             conn_label.update(f"Connections: {self.selected_pool_name} (introspection unavailable)")
 
     def load_events(self) -> None:

--- a/awx_tui/screens/the_network_queue.py
+++ b/awx_tui/screens/the_network_queue.py
@@ -92,7 +92,7 @@ class TheNetworkQueueScreen(Screen):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.event_data = []
-        self.pool_data = []  # List of (instance_name, client) tuples for pool table
+        self.pool_data = []  # List of (instance_name, client, conn_snapshot) tuples
         self.selected_pool_name = None
         self._refresh_timer = None
 
@@ -186,7 +186,18 @@ class TheNetworkQueueScreen(Screen):
                 try:
                     pool = client.session._transport._pool
                     connections = pool.connections
-                    idle = sum(1 for c in connections if c.is_idle())
+
+                    # Snapshot connection details now so load_connections sees the same state
+                    conn_snapshot = []
+                    idle = 0
+                    for conn in connections:
+                        info_str = str(conn.info())
+                        is_idle = conn.is_idle()
+                        is_closed = conn.is_closed()
+                        if is_idle:
+                            idle += 1
+                        conn_snapshot.append((info_str, is_idle, is_closed))
+
                     active = len(connections) - idle
 
                     pool_table.add_row(
@@ -198,10 +209,10 @@ class TheNetworkQueueScreen(Screen):
                         str(pool._max_connections),
                         str(pool._max_keepalive_connections),
                     )
-                    self.pool_data.append((name, client))
+                    self.pool_data.append((name, client, conn_snapshot))
                 except (Exception):
                     pool_table.add_row(name, "[yellow]●[/yellow] Unknown", "-", "-", "-", "-", "-")
-                    self.pool_data.append((name, client))
+                    self.pool_data.append((name, client, []))
             elif isinstance(client, AWXClient):
                 pool_table.add_row(
                     name,
@@ -212,23 +223,23 @@ class TheNetworkQueueScreen(Screen):
                     str(client.max_connections),
                     str(client.max_keepalive_connections),
                 )
-                self.pool_data.append((name, client))
+                self.pool_data.append((name, client, []))
             elif isinstance(client, InstanceConfig):
                 pool_table.add_row(name, "[dim]○[/dim] Not connected", "-", "-", "-", "-", "-")
-                self.pool_data.append((name, None))
+                self.pool_data.append((name, None, []))
             elif isinstance(client, MockAWXClient):
                 pool_table.add_row(name, "[dim]○[/dim] Mock", "-", "-", "-", "-", "-")
-                self.pool_data.append((name, None))
+                self.pool_data.append((name, None, []))
 
         # Restore selection
         if prev_selected:
-            for i, (pname, _) in enumerate(self.pool_data):
+            for i, (pname, _, _snapshot) in enumerate(self.pool_data):
                 if pname == prev_selected:
                     pool_table.cursor_coordinate = (i, 0)
                     break
 
     def load_connections(self) -> None:
-        """Load connections for the selected pool"""
+        """Load connections for the selected pool from the snapshot captured by load_pools"""
         conn_table = self.query_one("#conn_table", DataTable)
         conn_label = self.query_one("#conn_label", Static)
 
@@ -238,59 +249,45 @@ class TheNetworkQueueScreen(Screen):
             conn_label.update("Connections: Select a pool above")
             return
 
-        # Find the client for the selected pool
-        client = None
-        for pname, pclient in self.pool_data:
+        # Find the snapshot for the selected pool
+        conn_snapshot = None
+        for pname, _pclient, snapshot in self.pool_data:
             if pname == self.selected_pool_name:
-                client = pclient
+                conn_snapshot = snapshot
                 break
 
-        from awx_tui.client import AWXClient
-
-        if not isinstance(client, AWXClient) or not client.session or client.session.is_closed:
+        if conn_snapshot is None:
             conn_label.update(f"Connections: {self.selected_pool_name} (no active session)")
             return
 
-        try:
-            pool = client.session._transport._pool
-            connections = pool.connections
-            conn_label.update(f"Connections: {self.selected_pool_name} ({len(connections)} total)")
+        conn_label.update(f"Connections: {self.selected_pool_name} ({len(conn_snapshot)} total)")
 
-            for conn in connections:
-                info_str = str(conn.info())
+        for info_str, is_idle, is_closed in conn_snapshot:
+            # Parse conn.info() string: "'host:port', HTTP/1.1, IDLE, Request Count: 5"
+            origin = "unknown"
+            http_ver = "unknown"
+            req_count = "0"
 
-                # Parse conn.info() string: "'host:port', HTTP/1.1, IDLE, Request Count: 5"
-                origin = "unknown"
-                http_ver = "unknown"
-                req_count = "0"
+            origin_match = re.search(r"'([^']+)'", info_str)
+            if origin_match:
+                origin = origin_match.group(1)
 
-                # Extract origin
-                origin_match = re.search(r"'([^']+)'", info_str)
-                if origin_match:
-                    origin = origin_match.group(1)
+            http_match = re.search(r"(HTTP/[\d.]+)", info_str)
+            if http_match:
+                http_ver = http_match.group(1)
 
-                # Extract HTTP version
-                http_match = re.search(r"(HTTP/[\d.]+)", info_str)
-                if http_match:
-                    http_ver = http_match.group(1)
+            count_match = re.search(r"Request Count:\s*(\d+)", info_str)
+            if count_match:
+                req_count = count_match.group(1)
 
-                # Extract request count
-                count_match = re.search(r"Request Count:\s*(\d+)", info_str)
-                if count_match:
-                    req_count = count_match.group(1)
+            if is_closed:
+                state = "[red]CLOSED[/red]"
+            elif is_idle:
+                state = "[green]IDLE[/green]"
+            else:
+                state = "[yellow]ACTIVE[/yellow]"
 
-                # State
-                if conn.is_closed():
-                    state = "[red]CLOSED[/red]"
-                elif conn.is_idle():
-                    state = "[green]IDLE[/green]"
-                else:
-                    state = "[yellow]ACTIVE[/yellow]"
-
-                conn_table.add_row(origin, http_ver, state, req_count)
-
-        except (Exception):
-            conn_label.update(f"Connections: {self.selected_pool_name} (introspection unavailable)")
+            conn_table.add_row(origin, http_ver, state, req_count)
 
     def load_events(self) -> None:
         """Load connection events from app's connection event log"""
@@ -351,7 +348,7 @@ class TheNetworkQueueScreen(Screen):
             self.notify("No pool selected", severity="warning", timeout=2)
             return
 
-        for pname, pclient in self.pool_data:
+        for pname, pclient, _snapshot in self.pool_data:
             if pname == self.selected_pool_name:
                 from awx_tui.client import AWXClient
 

--- a/awx_tui/screens/the_network_queue.py
+++ b/awx_tui/screens/the_network_queue.py
@@ -94,7 +94,6 @@ class TheNetworkQueueScreen(Screen):
         self.event_data = []
         self.pool_data = []  # List of (instance_name, client, conn_snapshot) tuples
         self.selected_pool_name = None
-        self._refresh_timer = None
 
     def compose(self) -> ComposeResult:
         """Create the network queue dashboard layout"""
@@ -129,20 +128,7 @@ class TheNetworkQueueScreen(Screen):
         """Initialize the dashboard"""
         self.refresh_all()
 
-        # Start auto-refresh timer
-        refresh_interval = 1
-        if hasattr(self.app, "app_config") and self.app.app_config:
-            refresh_interval = self.app.app_config.preferences.get("network_queue_refresh_interval", 1)
-        if refresh_interval > 0:
-            self._refresh_timer = self.set_interval(refresh_interval, self._auto_refresh)
-
-    def _auto_refresh(self) -> None:
-        """Auto-refresh pool and connection tables (silent)"""
-        self.load_pools()
-        self.load_connections()
-        self.load_events()
-
-    def refresh_all(self) -> None:
+def refresh_all(self) -> None:
         """Load all three sections"""
         self.load_pools()
         self.load_connections()
@@ -333,8 +319,6 @@ class TheNetworkQueueScreen(Screen):
 
     def action_back(self) -> None:
         """Close the network queue screen"""
-        if self._refresh_timer:
-            self._refresh_timer.stop()
         self.app.pop_screen()
 
     def action_refresh(self) -> None:
@@ -377,6 +361,4 @@ class TheNetworkQueueScreen(Screen):
 
     def action_quit(self) -> None:
         """Quit the application"""
-        if self._refresh_timer:
-            self._refresh_timer.stop()
         self.app.exit()

--- a/awx_tui/screens/the_network_queue.py
+++ b/awx_tui/screens/the_network_queue.py
@@ -18,6 +18,9 @@ from textual.widgets import DataTable, Footer, Header, Static
 def _snapshot_pool_connections(pool) -> Tuple[List[Tuple[str, bool, bool]], int, int]:
     """Capture a point-in-time snapshot of all connections in a pool.
 
+    Uses httpcore pool internals (connections, is_idle, is_closed, info).
+    May break on major httpx/httpcore upgrades.
+
     Returns:
         Tuple of (conn_snapshot, idle_count, active_count) where conn_snapshot
         is a list of (info_str, is_idle, is_closed) tuples.

--- a/awx_tui/screens/the_network_queue.py
+++ b/awx_tui/screens/the_network_queue.py
@@ -7,7 +7,6 @@ per-connection details, and historical event log.
 
 import re
 
-import httpx
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Vertical
@@ -221,32 +220,6 @@ class TheNetworkQueueScreen(Screen):
                 pool_table.add_row(name, "[dim]○[/dim] Mock", "-", "-", "-", "-", "-")
                 self.pool_data.append((name, None))
 
-        # Add ping-pool if it exists
-        ping_client = getattr(instance_manager, "ping_client", None)
-        if ping_client and not ping_client.is_closed:
-            try:
-                pool = ping_client._transport._pool
-                connections = pool.connections
-                idle = sum(1 for c in connections if c.is_idle())
-                active = len(connections) - idle
-
-                pool_table.add_row(
-                    "ping-pool",
-                    "[cyan]●[/cyan] Active",
-                    str(len(connections)),
-                    str(active),
-                    str(idle),
-                    str(pool._max_connections),
-                    str(pool._max_keepalive_connections),
-                )
-                self.pool_data.append(("ping-pool", ping_client))
-            except (AttributeError, Exception):
-                pool_table.add_row("ping-pool", "[yellow]●[/yellow] Unknown", "-", "-", "-", "-", "-")
-                self.pool_data.append(("ping-pool", ping_client))
-        elif ping_client is None:
-            pool_table.add_row("ping-pool", "[dim]○[/dim] Not started", "-", "-", "-", "-", "-")
-            self.pool_data.append(("ping-pool", None))
-
         # Restore selection
         if prev_selected:
             for i, (pname, _) in enumerate(self.pool_data):
@@ -274,19 +247,12 @@ class TheNetworkQueueScreen(Screen):
 
         from awx_tui.client import AWXClient
 
-        # Resolve the httpx session - either from AWXClient or raw httpx.AsyncClient (ping-pool)
-        session = None
-        if isinstance(client, AWXClient) and client.session and not client.session.is_closed:
-            session = client.session
-        elif isinstance(client, httpx.AsyncClient) and not client.is_closed:
-            session = client
-
-        if session is None:
+        if not isinstance(client, AWXClient) or not client.session or client.session.is_closed:
             conn_label.update(f"Connections: {self.selected_pool_name} (no active session)")
             return
 
         try:
-            pool = session._transport._pool
+            pool = client.session._transport._pool
             connections = pool.connections
             conn_label.update(f"Connections: {self.selected_pool_name} ({len(connections)} total)")
 
@@ -391,8 +357,6 @@ class TheNetworkQueueScreen(Screen):
 
                 if isinstance(pclient, AWXClient) and pclient.session and not pclient.session.is_closed:
                     self.run_worker(self._do_close_pool(pclient, pname))
-                elif pname == "ping-pool" and isinstance(pclient, httpx.AsyncClient) and not pclient.is_closed:
-                    self.run_worker(self._do_close_ping_pool(pclient))
                 else:
                     self.notify(f"{pname}: No active session to close", severity="warning", timeout=2)
                 return
@@ -401,20 +365,6 @@ class TheNetworkQueueScreen(Screen):
         """Actually close an AWXClient pool"""
         await client.close()
         self.notify(f"Pool closed: {name}", timeout=2)
-        self.refresh_all()
-
-    async def _do_close_ping_pool(self, client) -> None:
-        """Close the ping-pool"""
-        instance_manager = getattr(self.app, "instance_manager", None)
-        if instance_manager:
-            from awx_tui.ping_checker import _log_ping_connection_event
-
-            _log_ping_connection_event(
-                getattr(self.app, "connection_event_log", None), "ping-pool", "POOL_CLOSED", "Closed from Network Queue"
-            )
-            await client.aclose()
-            instance_manager.ping_client = None
-        self.notify("Pool closed: ping-pool", timeout=2)
         self.refresh_all()
 
     def action_purge(self) -> None:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -23,6 +23,8 @@ instances:
     verify_ssl: true                        # Optional: Verify SSL certs (default: true)
     dashboard: classic                      # Optional: Dashboard layout ('classic' or 'sleek') (default: classic)
     description: "Development AWX 2"        # Optional: Human-readable description
+    # pool_max_connections: 20              # Optional: Per-instance max pool connections (default: from preferences)
+    # pool_max_keepalive_connections: 10    # Optional: Per-instance max keepalive connections (default: from preferences)
 
   # Example: Password-based authentication
   dev1:
@@ -83,6 +85,11 @@ preferences:
   # --- Instance Management Settings ---
   instance_selection_refresh_interval: 5          # Instance health check interval (default: 5)
   show_instance_in_header: true                   # Show active instance in header (default: true)
+
+  # --- Connection Pool Settings ---
+  pool_max_connections: 20                        # Max connections per AWX instance pool (default: 20)
+  pool_max_keepalive_connections: 10              # Max keepalive connections per pool (default: 10)
+  network_queue_refresh_interval: 1               # Network Queue dashboard refresh interval in seconds (default: 1)
 
   # --- Development/Testing ---
   mock_mode: false                                # Enable mock mode (default: false)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -89,7 +89,6 @@ preferences:
   # --- Connection Pool Settings ---
   pool_max_connections: 20                        # Max connections per AWX instance pool (default: 20)
   pool_max_keepalive_connections: 10              # Max keepalive connections per pool (default: 10)
-  network_queue_refresh_interval: 1               # Network Queue dashboard refresh interval in seconds (default: 1)
 
   # --- Development/Testing ---
   mock_mode: false                                # Enable mock mode (default: false)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -169,7 +169,10 @@ class TestAWXClientContext:
 
     @pytest.mark.asyncio
     async def test_connection_pool_limits_configured(self, token_instance):
-        """Test httpx client has explicit connection pool limits"""
+        """Test httpx client has explicit connection pool limits.
+
+        Accesses httpx/httpcore private internals — may need updating on major upgrades.
+        """
         client = AWXClient(token_instance)
 
         async with client:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -111,17 +111,73 @@ class TestAWXClientContext:
             assert isinstance(client.session, httpx.AsyncClient)
 
     @pytest.mark.asyncio
-    async def test_context_manager_closes_session(self, token_instance):
-        """Test session closed on exit"""
+    async def test_session_persists_across_context_entries(self, token_instance):
+        """Test session is NOT recreated on repeated context entry (persistent session)"""
+        client = AWXClient(token_instance)
+
+        async with client:
+            session1 = client.session
+            assert session1 is not None
+
+        # Enter context again - should reuse same session
+        async with client:
+            session2 = client.session
+            assert session2 is session1
+
+    @pytest.mark.asyncio
+    async def test_session_not_closed_on_context_exit(self, token_instance):
+        """Test session remains open after exiting context manager"""
         client = AWXClient(token_instance)
 
         async with client:
             session = client.session
             assert session is not None
 
-        # Session should be closed after exit
-        # (httpx doesn't provide easy way to check if closed, so just verify it was set)
-        assert session is not None
+        # Session should still be open after context exit
+        assert client.session is not None
+        assert not client.session.is_closed
+
+    @pytest.mark.asyncio
+    async def test_explicit_close_closes_session(self, token_instance):
+        """Test explicit close() tears down the session"""
+        client = AWXClient(token_instance)
+
+        async with client:
+            assert client.session is not None
+
+        await client.close()
+
+        # Session should be None after close
+        assert client.session is None
+
+    @pytest.mark.asyncio
+    async def test_reopen_after_close(self, token_instance):
+        """Test entering context after close() creates a new session"""
+        client = AWXClient(token_instance)
+
+        async with client:
+            session1 = client.session
+
+        await client.close()
+        assert client.session is None
+
+        # Re-entering context should create a new session
+        async with client:
+            session2 = client.session
+            assert session2 is not None
+            assert session2 is not session1
+
+    @pytest.mark.asyncio
+    async def test_connection_pool_limits_configured(self, token_instance):
+        """Test httpx client has explicit connection pool limits"""
+        client = AWXClient(token_instance)
+
+        async with client:
+            pool = client.session._transport._pool
+            assert pool._max_connections == 20
+            assert pool._max_keepalive_connections == 10
+
+        await client.close()
 
     @pytest.mark.asyncio
     async def test_password_auth_uses_basic_auth(self, password_instance):
@@ -129,6 +185,7 @@ class TestAWXClientContext:
         async with AWXClient(password_instance) as client:
             # Session should have auth configured
             assert client.session.auth is not None
+        await client.close()
 
 
 class TestSensitiveDataMasking:

--- a/tests/test_instance_manager.py
+++ b/tests/test_instance_manager.py
@@ -366,3 +366,41 @@ class TestInstanceManagerAsync:
         result = await manager.test_connection()
 
         assert result is False
+
+
+@pytest.mark.asyncio
+class TestInstanceManagerCleanup:
+    """Test client cleanup and session lifecycle"""
+
+    async def test_close_all_clients(self):
+        """Test close_all_clients closes all AWXClient sessions"""
+        config = AppConfig()
+        config.instances["awx-1"] = InstanceConfig(
+            name="awx-1", url="https://awx1.example.com", auth_method="token", username="admin", token="token1"
+        )
+        config.instances["awx-2"] = InstanceConfig(
+            name="awx-2", url="https://awx2.example.com", auth_method="token", username="admin", token="token2"
+        )
+        manager = InstanceManager(config, mock_mode=False)
+
+        # Get clients to trigger creation and open sessions
+        manager.switch_to("awx-1")
+        client1 = manager.get_current_client()
+        async with client1:
+            pass  # Opens the session
+
+        manager.switch_to("awx-2")
+        client2 = manager.get_current_client()
+        async with client2:
+            pass  # Opens the session
+
+        # Both sessions should be open
+        assert client1.session is not None
+        assert client2.session is not None
+
+        # Close all
+        await manager.close_all_clients()
+
+        # Sessions should be torn down
+        assert client1.session is None
+        assert client2.session is None


### PR DESCRIPTION
## Summary

  - Fix network connection errors caused by per-request httpx client creation/destruction during dashboard refresh cycles
  - Add persistent httpx connection pooling per AWX instance with configurable pool limits
  - Add The Network Queue (Ctrl+N) — a connection pool management dashboard
  - Add persistent shared ping-pool for instance health checks

## Details

  Every dashboard refresh (every 1-5 seconds) was creating 14-16 new TCP+TLS connections, using them once, and immediately tearing them down. This caused TCP TIME_WAIT accumulation and
  connection storms that triggered sporadic "Network error connecting to..." errors.

  The fix makes httpx.AsyncClient sessions persistent per AWX instance. Sessions are created on first use and stay alive until explicitly closed or app exit. All ~30+ existing async with
  client: call sites work unchanged.

  The Network Queue (Ctrl+N) provides:
  - Pool overview table with live stats per instance
  - Per-connection detail table (origin, HTTP version, state, request count)
  - Pool event log (creation, closure, exhaustion events)
  - Close pools from the UI (Ctrl+K)
  - Manual refresh via R key (consistent with other debug screens)

  Pool limits are configurable at three levels (runtime > per-instance > global preferences):
  - pool_max_connections (default: 20)
  - pool_max_keepalive_connections (default: 10)

## Post-implementation fixes

The following issues were identified during code review and fixed in follow-up commits:

  - **Fix `debug_logger` AttributeError** — `test_connection()` referenced a non-existent `self.debug_logger` attribute, causing a crash when testing real (non-mock) instances that hadn't been lazily initialized
  - **Fix session reference outside context manager** — Replaced misleading `async with client:` pattern with direct `__aenter__()` call, since the session was used after the block exited
  - **Fix unreliable cleanup on quit** — Moved `close_all_clients()` from a fire-and-forget `run_worker()` in `action_quit` to the `on_unmount` lifecycle hook where it can be properly awaited
  - **Remove redundant code `_log_ping_connection_event`** — Function was defined but never called; ping outcomes are already logged via `api_call_log`
  - **Remove unused `network_queue_refresh_interval` config** — Auto-refresh timer was removed in d31eb6b but the config key was left behind in defaults, README, and example config
  - **Fix inconsistent timestamp formatting** — Standardized all ping_checker log timestamps to use millisecond precision, matching `AWXClient._log_api_call`
  - **Persist pool settings in config save** — `pool_max_connections` and `pool_max_keepalive_connections` were loaded from YAML but silently dropped on save
  - **Document private API access** — Added comments noting that `_transport._pool` introspection relies on httpx/httpcore internals that may break on major upgrades
  - **Document concurrency assumption** — Added comment noting that `connection_event_log` is a shared mutable list safe under single-threaded asyncio + CPython GIL but not thread-safe

## Test plan

  - All 203 tests passing
  - make run-mock — verify Network Queue opens with Ctrl+N
  - Connect to real AWX — verify dashboard refreshes without network errors
  - Verify connection reuse via request count in Network Queue
  - Test Ctrl+K pool close and automatic recreation on next refresh
  - Verify pool limits from config.yaml are applied

  🤖 AIA: EAI Hin R Claude Code v1.0 (Claude Opus 4.6)

  Vibe-Coder: Andrew Potozniak potozniak@redhat.com

  Assisted-By: Claude noreply@anthropic.com