### PR TITLE
Add vim-style hjkl navigation and remap Load More to M key

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,11 +284,12 @@ make clean       # Remove venv and build artifacts
 - `Ctrl+T` - Advanced API Mode
 - `Ctrl+O` - The Loaf (notification history)
 - `Ctrl+N` - The Network Queue (connection pool management)
+- `H`/`J`/`K`/`L` - Vim-style navigation (left/down/up/right)
 - `I` or `?` - AWX-TUI Info
 
 ### Dashboard
 - `Tab` - Switch between tables
-- `↑`/`↓` - Navigate
+- `↑`/`↓` or `K`/`J` - Navigate
 - `Enter` - Job details
 - `R` - Refresh
 

--- a/awx_tui/app.py
+++ b/awx_tui/app.py
@@ -320,6 +320,21 @@ class AWXTUIApp(App):
         # Hot reload manager will restore the previous screen if in dev mode
         await self.hot_reload.try_restore_screen()
 
+    HJKL_MAP = {"h": "left", "j": "down", "k": "up", "l": "right"}
+
+    def on_key(self, event) -> None:
+        """Remap hjkl to arrow keys for vim-style navigation"""
+        if event.key not in self.HJKL_MAP:
+            return
+        # Skip remapping when typing in text input widgets
+        from textual.widgets import Input, TextArea
+
+        if isinstance(self.focused, (Input, TextArea)):
+            return
+        self.simulate_key(self.HJKL_MAP[event.key])
+        event.stop()
+        event.prevent_default()
+
     def action_quit(self) -> None:
         """Quit the application"""
         self.exit()

--- a/awx_tui/screens/active_jobs.py
+++ b/awx_tui/screens/active_jobs.py
@@ -167,7 +167,7 @@ class ActiveJobsScreen(Screen):
         ("4", "goto_projects", "Projects"),
         ("5", "goto_templates", "Templates"),
         ("6", "goto_inventories", "Inventories"),
-        ("l", "load_more", "Load More"),
+        ("m", "load_more", "Load More"),
         ("ctrl+k", "cancel_job", "Cancel"),
         ("ctrl+f", "focus_filter", "Filter"),
         ("ctrl+d", "debug_console", "Debug"),

--- a/awx_tui/screens/historic_jobs.py
+++ b/awx_tui/screens/historic_jobs.py
@@ -167,7 +167,7 @@ class HistoricJobsScreen(Screen):
         ("4", "goto_projects", "Projects"),
         ("5", "goto_templates", "Templates"),
         ("6", "goto_inventories", "Inventories"),
-        ("l", "load_more", "Load More"),
+        ("m", "load_more", "Load More"),
         ("ctrl+r", "relaunch_job", "Relaunch"),
         ("ctrl+f", "focus_filter", "Filter"),
         ("ctrl+d", "debug_console", "Debug"),


### PR DESCRIPTION
Added global hjkl key remapping at the app level for vim-style navigation across all screens and DataTable widgets. The remapping is automatically disabled when typing in Input or TextArea widgets to avoid interfering with text entry on Create/Update screens and Advanced API Mode.

Changes:
- Added on_key handler in AWXTUIApp to translate hjkl to arrow keys
- Remapped Load More binding from L to M on Active Jobs and Historic Jobs screens to free the L key for vim navigation
- Updated README key bindings documentation

🤖 AIA: EAI Hin R Claude Code v1.0 (Claude Opus 4.6)

Vibe-Coder: Andrew Potozniak <potozniak@redhat.com>

Assisted-By: Claude <noreply@anthropic.com>

Reference: #21 