### PR TITLE
Makefile: add missing clean-config target and document lint targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup install test run run-mock dev dev-mock dev-notmux dev-mock-notmux dev-mock-sleek console stop-dev clean
+.PHONY: help setup install test test-basic coverage run run-mock dev dev-mock dev-mock-debug dev-notmux dev-mock-notmux dev-mock-sleek console stop-dev lint lint-fix clean clean-config
 
 # Use bash for all commands
 SHELL := /bin/bash
@@ -28,6 +28,10 @@ help:
 	@echo "  make test         - Run all tests"
 	@echo "  make test-basic   - Run basic smoke tests"
 	@echo "  make coverage     - Run tests with coverage report"
+	@echo ""
+	@echo "Linting & Formatting:"
+	@echo "  make lint         - Check linting and formatting with ruff and black"
+	@echo "  make lint-fix     - Apply linting and formatting fixes with ruff and black"
 	@echo ""
 	@echo "Cleanup:"
 	@echo "  make clean        - Remove venv and build artifacts"
@@ -194,3 +198,8 @@ clean:
 	rm -rf .coverage
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	@echo "✅ Cleanup complete!"
+
+clean-config:
+	@echo "Removing config.yaml..."
+	rm -f config.yaml
+	@echo "✅ config.yaml removed!"


### PR DESCRIPTION
## Summary

The `help` target advertises `make clean-config` to remove `config.yaml`, but no such target existed — running it failed with `No rule to make target 'clean-config'`. This PR adds the target so the help text works as advertised.

It also surfaces the existing `lint` and `lint-fix` targets in the help output under a new *Linting & Formatting* section (previously undiscoverable from `make help`), and brings the `.PHONY` declaration up to date with the targets that have been added to the Makefile over time.

## Changes

- `Makefile`
  - Add `clean-config:` target that removes `config.yaml` (matches the existing `help` description).
  - Add a *Linting & Formatting* section to `help` listing `make lint` and `make lint-fix`.
  - Extend `.PHONY` with `test-basic`, `coverage`, `dev-mock-debug`, `lint`, `lint-fix`, and `clean-config` — none of them produce files named after themselves, so they should be phony.

## Test plan

Validated locally with GNU Make 4.x on Ubuntu (WSL):

- [x] `make help` shows the new *Linting & Formatting* section and `make clean-config` is still listed.
- [x] `make clean-config` removes the target file without error (tested against a throwaway `config.yaml.testfile` via `sed`-patched recipe to avoid touching a real config).
- [x] `make -n lint` and `make -n lint-fix` emit the same recipes as on `devel` (unchanged).
- [x] `make -n` output compared between `devel` and this PR for `test`, `test-basic`, `coverage`, `lint`, `lint-fix`, `clean`, `run-mock`, `stop-dev`, `dev-mock-debug` — all **identical**, confirming no existing target behaviour changed.

## Notes

No code or packaging changes; this is a Makefile-only fix.